### PR TITLE
Added format descriptions.

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -200,7 +200,28 @@ class Source(models.Model):
         _('media format'),
         max_length=200,
         default=settings.MEDIA_FORMATSTR_DEFAULT,
-        help_text=_('File format to use for saving files')
+        help_text=_("""File format to use for saving files
+Valid options:
+    'yyyymmdd': 20210201,
+    'yyyy_mm_dd': 2021-02-01,
+    'yyyy': 2021,
+    'mm': 02,
+    'dd': 01,
+    'source': <Example here>,
+    'source_full': <Example here>,
+    'title': <Example here>,
+    'title_full': <Example here>,
+    'key': <Example here>,
+    'playlist_index': 1,
+    'playlist_title': <Example here>,
+    'ext': mp4,
+    'resolution': 1280x720,
+    'height': 720,
+    'width': 1280,
+    'vcodec': h264,
+    'acodec': mp3,
+    'fps': 24,
+    'hdr': <Example here>""")
     )
     index_schedule = models.IntegerField(
         _('index schedule'),

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -200,28 +200,7 @@ class Source(models.Model):
         _('media format'),
         max_length=200,
         default=settings.MEDIA_FORMATSTR_DEFAULT,
-        help_text=_("""File format to use for saving files
-Valid options:
-    'yyyymmdd': 20210201,
-    'yyyy_mm_dd': 2021-02-01,
-    'yyyy': 2021,
-    'mm': 02,
-    'dd': 01,
-    'source': <Example here>,
-    'source_full': <Example here>,
-    'title': <Example here>,
-    'title_full': <Example here>,
-    'key': <Example here>,
-    'playlist_index': 1,
-    'playlist_title': <Example here>,
-    'ext': mp4,
-    'resolution': 1280x720,
-    'height': 720,
-    'width': 1280,
-    'vcodec': h264,
-    'acodec': mp3,
-    'fps': 24,
-    'hdr': <Example here>""")
+        help_text=_('File format to use for saving files, detailed options at bottom of page.')
     )
     index_schedule = models.IntegerField(
         _('index schedule'),


### PR DESCRIPTION
One of my first questions while evaluating tubesync was what format options are available. 
I added format descriptions to the media format help_text based on the options I see in the models.

Edit: I am not sure why the last pipeline is failing, My changes should not relate to that.