### PR TITLE
Fix meeb/tubesync#90: Match media on source and id

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -175,7 +175,7 @@ def index_source_task(source_id):
             # Video has no unique key (ID), it can't be indexed
             continue
         try:
-            media = Media.objects.get(key=key)
+            media = Media.objects.get(key=key, source=source)
         except Media.DoesNotExist:
             media = Media(key=key)
         media.source = source


### PR DESCRIPTION
When looking for existing media objets during source indexing, the query should match both the key (the video's ID) and the source. Otherwise, a media object with a given key can only ever exist once, which breaks the case where multiple playlists share a video.