### PR TITLE
Build docker image for amd64 and arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,19 +35,24 @@ jobs:
   containerise:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Log into GitHub Container Registry
-      run: echo "${{ secrets.REGISTRY_ACCESS_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        platforms: linux/amd64
-        push: true
-        tags: ghcr.io/meeb/${{ env.IMAGE_NAME }}:latest
-        cache-from: type=registry,ref=ghcr.io/meeb/${{ env.IMAGE_NAME }}:latest
-        cache-to: type=inline
-        build-args: |
-          IMAGE_NAME=${{ env.IMAGE_NAME }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.REGISTRY_ACCESS_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Lowercase github username for ghcr
+        id: string
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.actor }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=registry,ref=ghcr.io/${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline
+          build-args: |
+            IMAGE_NAME=${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,23 +11,23 @@ jobs:
   containerise:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Get tag
-      id: tag
-      uses: dawidd6/action-get-tag@v1
-    - uses: docker/build-push-action@v2
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Log into GitHub Container Registry
-      run: echo "${{ secrets.REGISTRY_ACCESS_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        platforms: linux/amd64
-        push: true
-        tags: ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-        cache-from: type=registry,ref=ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-        cache-to: type=inline
-        build-args: |
-          IMAGE_NAME=${{ env.IMAGE_NAME }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+      - uses: docker/build-push-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.REGISTRY_ACCESS_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          # cache-from: type=registry,ref=ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          # cache-to: type=inline
+          build-args: |
+            IMAGE_NAME=${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,13 +21,18 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.REGISTRY_ACCESS_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Lowercase github username for ghcr
+        id: string
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.actor }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.actor }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.actor }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          tags: ghcr.io/${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.actor }}${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
           cache-to: type=inline
           build-args: |
             IMAGE_NAME=${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          # cache-from: type=registry,ref=ghcr.io/meeb/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          # cache-to: type=inline
+          tags: ghcr.io/${{ github.actor }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.actor }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-to: type=inline
           build-args: |
             IMAGE_NAME=${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.actor }}${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=registry,ref=ghcr.io/${{ steps.string.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
           cache-to: type=inline
           build-args: |
             IMAGE_NAME=${{ env.IMAGE_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM debian:bullseye-slim
 
 ARG TARGETPLATFORM
-ARG ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "amd64"  ;; \
-  "linux/arm64")   echo "aarch64" ;; \
-  *)               echo ""        ;; esac)
+# ARG ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
+#   "linux/amd64")   echo "amd64"  ;; \
+#   "linux/arm64")   echo "aarch64" ;; \
+#   *)               echo ""        ;; esac)
 ARG S6_VERSION="2.2.0.3"
-RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "amd64"  ;; \
-  "linux/arm64")   echo "aarch64" ;; \
-  *)               echo ""        ;; esac) \
-  && echo "ARCH=${ARCH}, ARCH2=$ARCH"
 
 ENV DEBIAN_FRONTEND="noninteractive" \
   HOME="/root" \
@@ -18,11 +13,19 @@ ENV DEBIAN_FRONTEND="noninteractive" \
   LANG="en_US.UTF-8" \
   LC_ALL="en_US.UTF-8" \
   TERM="xterm" \
-  S6_EXPECTED_SHA256="a7076cf205b331e9f8479bbb09d9df77dbb5cd8f7d12e9b74920902e0c16dd98" \
   S6_DOWNLOAD="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-${ARCH}.tar.gz"
 
 # Install third party software
-RUN set -x && \
+RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
+  "linux/amd64")   echo "amd64"  ;; \
+  "linux/arm64")   echo "aarch64" ;; \
+  *)               echo ""        ;; esac) && \
+  export S6_EXPECTED_SHA256=$(case ${TARGETPLATFORM:-linux/amd64} in \
+  "linux/amd64")   echo "a7076cf205b331e9f8479bbb09d9df77dbb5cd8f7d12e9b74920902e0c16dd98"  ;; \
+  "linux/arm64")   echo "84f585a100b610124bb80e441ef2dc2d68ac2c345fd393d75a6293e0951ccfc5" ;; \
+  *)               echo ""        ;; esac) && \
+  echo "Building for arch: ${ARCH}, expecting S6 SHA256: ${S6_EXPECTED_SHA256}" && \
+  set -x && \
   apt-get update && \
   apt-get -y --no-install-recommends install locales && \
   echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
 FROM debian:bullseye-slim
 
 ARG TARGETPLATFORM
-ARG ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "amd64"  ;; \
-  "linux/arm64")   echo "aarch64" ;; \
-  *)               echo ""        ;; esac)
-ARG ARCH44=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "amd64"  ;; \
-  "linux/arm64")   echo "aarch64" ;; \
-  *)               echo ""        ;; esac)
 ARG S6_VERSION="2.2.0.3"
 
 ENV DEBIAN_FRONTEND="noninteractive" \
@@ -16,8 +8,7 @@ ENV DEBIAN_FRONTEND="noninteractive" \
   LANGUAGE="en_US.UTF-8" \
   LANG="en_US.UTF-8" \
   LC_ALL="en_US.UTF-8" \
-  TERM="xterm" \
-  S6_DOWNLOAD="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-${ARCH}.tar.gz"
+  TERM="xterm"
 
 # Install third party software
 RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
@@ -27,6 +18,10 @@ RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
   export S6_EXPECTED_SHA256=$(case ${TARGETPLATFORM:-linux/amd64} in \
   "linux/amd64")   echo "a7076cf205b331e9f8479bbb09d9df77dbb5cd8f7d12e9b74920902e0c16dd98"  ;; \
   "linux/arm64")   echo "84f585a100b610124bb80e441ef2dc2d68ac2c345fd393d75a6293e0951ccfc5" ;; \
+  *)               echo ""        ;; esac) && \
+  export S6_DOWNLOAD=$(case ${TARGETPLATFORM:-linux/amd64} in \
+  "linux/amd64")   echo "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz"  ;; \
+  "linux/arm64")   echo "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-aarch64.tar.gz" ;; \
   *)               echo ""        ;; esac) && \
   echo "Building for arch: ${ARCH}|${ARCH44}, downloading S6 from: ${S6_DOWNLOAD}}, expecting S6 SHA256: ${S6_EXPECTED_SHA256}" && \
   set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
 ARG TARGETPLATFORM
-# ARG ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
-#   "linux/amd64")   echo "amd64"  ;; \
-#   "linux/arm64")   echo "aarch64" ;; \
-#   *)               echo ""        ;; esac)
+ARG ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
+  "linux/amd64")   echo "amd64"  ;; \
+  "linux/arm64")   echo "aarch64" ;; \
+  *)               echo ""        ;; esac)
+ARG ARCH44=$(case ${TARGETPLATFORM:-linux/amd64} in \
+  "linux/amd64")   echo "amd64"  ;; \
+  "linux/arm64")   echo "aarch64" ;; \
+  *)               echo ""        ;; esac)
 ARG S6_VERSION="2.2.0.3"
 
 ENV DEBIAN_FRONTEND="noninteractive" \
@@ -24,7 +28,7 @@ RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
   "linux/amd64")   echo "a7076cf205b331e9f8479bbb09d9df77dbb5cd8f7d12e9b74920902e0c16dd98"  ;; \
   "linux/arm64")   echo "84f585a100b610124bb80e441ef2dc2d68ac2c345fd393d75a6293e0951ccfc5" ;; \
   *)               echo ""        ;; esac) && \
-  echo "Building for arch: ${ARCH}, expecting S6 SHA256: ${S6_EXPECTED_SHA256}" && \
+  echo "Building for arch: ${ARCH}|${ARCH44}, downloading S6 from: ${S6_DOWNLOAD}}, expecting S6 SHA256: ${S6_EXPECTED_SHA256}" && \
   set -x && \
   apt-get update && \
   apt-get -y --no-install-recommends install locales && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
 COPY tubesync /app
 COPY tubesync/tubesync/local_settings.py.container /app/tubesync/local_settings.py
 
+# Copy over pip.conf to use piwheels
+COPY pip.conf /etc/pip.conf
+
 # Add Pipfile
 COPY Pipfile /app/Pipfile
 COPY Pipfile.lock /app/Pipfile.lock
@@ -62,6 +65,7 @@ RUN set -x && \
   python3-pip \
   python3-dev \
   gcc \
+  g++ \
   make \
   default-libmysqlclient-dev \
   libmariadb3 \
@@ -101,6 +105,7 @@ RUN set -x && \
   python3-pip \
   python3-dev \
   gcc \
+  g++ \
   make \
   default-libmysqlclient-dev \
   postgresql-common \

--- a/Pipfile
+++ b/Pipfile
@@ -3,11 +3,6 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[[source]]
-name = "piwheels"
-url = "https://www.piwheels.org/simple"
-verify_ssl = true
-
 [dev-packages]
 
 [packages]

--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,11 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+[[source]]
+name = "piwheels"
+url = "https://www.piwheels.org/simple"
+verify_ssl = true
+
 [dev-packages]
 
 [packages]

--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,2 @@
+[global]
+extra-index-url=https://www.piwheels.org/simple


### PR DESCRIPTION
As per the title. You should note the build time for arm64 takes a while (entire containerize job was 33 minutes) because python needs to build the libsass library for arm64 every time. libsass does not provide arm64 prebuild neither does piwheels. I am not very familiar with python, is there a for us the prebuild libsass once and have it download that?

I tested the image on my PI 4 and it works perfectly, if anyone wants to test or use it for now, you can use:
`ghcr.io/sweetmnm/tubesync`