### PR TITLE
Skip metadata and thumbnails if they are past the cutoff date

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -147,7 +147,7 @@ def media_post_save(sender, instance, created, **kwargs):
         instance.save()
         post_save.connect(media_post_save, sender=Media)
     # If the media is missing metadata schedule it to be downloaded
-    if not instance.metadata:
+    if not instance.metadata and not instance.skip:
         log.info(f'Scheduling task to download metadata for: {instance.url}')
         verbose_name = _('Downloading metadata for "{}"')
         download_media_metadata(
@@ -159,7 +159,7 @@ def media_post_save(sender, instance, created, **kwargs):
     # If the media is missing a thumbnail schedule it to be downloaded
     if not instance.thumb_file_exists:
         instance.thumb = None
-    if not instance.thumb:
+    if not instance.thumb and not instance.skip:
         thumbnail_url = instance.thumbnail
         if thumbnail_url:
             log.info(f'Scheduling task to download thumbnail for: {instance.name} '

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -277,6 +277,11 @@ def download_media_thumbnail(media_id, url):
     except Media.DoesNotExist:
         # Task triggered but the media no longer exists, do nothing
         return
+    if media.skip:
+        # Media was toggled to be skipped after the task was scheduled
+        log.warn(f'Download task triggered for media: {media} (UUID: {media.pk}) but '
+                 f'it is now marked to be skipped, not downloading thumbnail')
+        return
     width = getattr(settings, 'MEDIA_THUMBNAIL_WIDTH', 430)
     height = getattr(settings, 'MEDIA_THUMBNAIL_HEIGHT', 240)
     i = get_remote_image(url)


### PR DESCRIPTION
Hey, I'm playing around with tubesync and I'm trying to add a couple of large channels and bumped into the #260 issue.

Would something like this work? I'm not really familiar with django or the process that media and tasks go through so I might be very off base here. I am also making the assumption that media.skip has already been set on the media entry before we get to the signaling for the thumbnails, which might not be correct.

I'm currently having some issues building the container or even installing deps locally on macos so I haven't tested this; I blame the fact it's pretty late here and will give it another shot tomorrow.

Any issues and ideally suggestions for getting this right would be appreciated!
Regards, George