### PR TITLE
Increase gunicorn timeout for initial sync of large channels

### DIFF
--- a/tubesync/tubesync/gunicorn.py
+++ b/tubesync/tubesync/gunicorn.py
@@ -22,7 +22,7 @@ def get_bind():
 
 
 workers = get_num_workers()
-timeout = 30
+timeout = 300
 chdir = '/app'
 daemon = False
 pidfile = '/run/app/gunicorn.pid'


### PR DESCRIPTION
**Issue:**  Gunicorn may timeout when performing the initial sync of a large channel.

**Logs:**

> 2022-12-16 15:17:59,104 [tubesync/INFO] Scheduling task to download thumbnail for: Ruining another player's equipment in D&D from: https://i.ytimg.com/vi_webp/7rOMD9yz_IQ/maxresdefault.webp
[2022-12-16 15:17:59 -0600] [484] [CRITICAL] WORKER TIMEOUT (pid:141667) 2022/12/16 15:17:59 [error] 512#512: *227 upstream prematurely closed connection while reading response header from upstream, client: 10.12.x.x, server: _, request: "POST /source-update/7196ec57-55c5-41b1-9ddb-16acc24e0b84 HTTP/1.1", upstream: "http://127.0.0.1:8080/source-update/7196ec57-55c5-41b1-9ddb-16acc24e0b84", host: "10.12.x.x:4848", referrer: "http://10.12.x.x:4848/source-update/7196ec57-55c5-41b1-9ddb-16acc24e0b84"

**To reproduce:**

1. Add source with over 1,000 videos. Ex: https://www.youtube.com/c/@VivaLaDirtLeague
2. Run an initial sync. Observe the timeout.