### PR TITLE
Update README-FAQ regarding `Locking Failed`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ etc.). Configuration of this is beyond the scope of this README.
 
 Just `amd64` for the moment. Others may be made available if there is demand.
 
+### The pipenv install fails with "Locking failed"!
+
+Make sure that you have `mysql_config` or `mariadb_config` available, as required by the python module `mysqlclient`. On Debian-based systems this is usually found in the package `libmysqlclient-dev`
+
 
 # Advanced configuration
 


### PR DESCRIPTION
Just a small addition as I was locally trying to get up the development environment (instead of using a .devcontainer/container for developing) and ran across this weird error:

```
(tubesync) kuhnchris@ERIKA-MINIPC:~/tubesync$ pipenv install
Pipfile.lock not found, creating...
Locking [packages] dependencies...
Building requirements...
Resolving dependencies...
✘ Locking Failed!
⠧ Locking...
ERROR:pip.subprocessor:[present-rich] python setup.py egg_info exited with 1
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/resolver.py", line 811, in _main
[ResolutionFailure]:       resolve_packages(
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/resolver.py", line 759, in resolve_packages
[ResolutionFailure]:       results, resolver = resolve(
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/resolver.py", line 738, in resolve
[ResolutionFailure]:       return resolve_deps(
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/utils/resolver.py", line 1102, in resolve_deps
[ResolutionFailure]:       results, hashes, markers_lookup, resolver, skipped = actually_resolve_deps(
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/utils/resolver.py", line 899, in actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File "/home/kuhnchris/.local/lib/python3.10/site-packages/pipenv/utils/resolver.py", line 687, in resolve
[ResolutionFailure]:       raise ResolutionFailure(message=str(e))
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  You can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: metadata generation failed
```
After much trial-and-error, I found out that this was due to mysqlclient being... "not friendly".

```
Collecting mysqlclient
  Using cached mysqlclient-2.1.1.tar.gz (88 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      /bin/sh: 1: mysql_config: not found
      /bin/sh: 1: mariadb_config: not found
      /bin/sh: 1: mysql_config: not found
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-lx0r25qj/mysqlclient_57a1f048c4ae4e4db34629af62039209/setup.py", line 15, in <module>
          metadata, options = get_config()
        File "/tmp/pip-install-lx0r25qj/mysqlclient_57a1f048c4ae4e4db34629af62039209/setup_posix.py", line 70, in get_config
          libs = mysql_config("libs")
        File "/tmp/pip-install-lx0r25qj/mysqlclient_57a1f048c4ae4e4db34629af62039209/setup_posix.py", line 31, in mysql_config
          raise OSError("{} not found".format(_mysql_config_path))
      OSError: mysql_config not found
      mysql_config --version
      mariadb_config --version
      mysql_config --libs
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```

A quick `apt install` fixed my issue tho.
```
(tubesync) kuhnchris@ERIKA-MINIPC:~/tubesync$ sudo apt install libmysqlclient-dev
...
(tubesync) kuhnchris@ERIKA-MINIPC:~/tubesync$ pipenv install
Pipfile.lock not found, creating...
Locking [packages] dependencies...
Building requirements...
Resolving dependencies...
✔ Success!
Locking [dev-packages] dependencies...
Updated Pipfile.lock (a8b6cd12970bce4ea2de47aed437cf99ab5e63253a53e587e885c63b32ebc9a1)!
Installing dependencies from Pipfile.lock (ebc9a1)...
(tubesync) kuhnchris@ERIKA-MINIPC:~/tubesync$
```

So, to make it easier in the future, it'd make sense to add that to the FAQ. ;-)