### PR TITLE
Fix bug getting content_type for "audio only"

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1140,7 +1140,11 @@ class Media(models.Model):
     def content_type(self):
         if not self.downloaded:
             return 'video/mp4'
-        vcodec = self.downloaded_video_codec.lower()
+        vcodec = self.downloaded_video_codec
+        if vcodec is None:
+            return 'audio/ogg'
+
+        vcodec = vcodec.lower()
         if vcodec == 'vp9':
             return 'video/webm'
         else:

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1142,7 +1142,18 @@ class Media(models.Model):
             return 'video/mp4'
         vcodec = self.downloaded_video_codec
         if vcodec is None:
-            return 'audio/ogg'
+            acodec = self.downloaded_audio_codec
+            if acodec is None:
+                raise TypeError() # nothing here.
+            
+            acodec = acodec.lower()
+            if acodec == "mp4a":
+                return "audio/mp4"
+            elif acodec == "opus":
+                return "audio/opus"
+            else:
+                # fall-fall-back.
+                return 'audio/ogg'
 
         vcodec = vcodec.lower()
         if vcodec == 'vp9':


### PR DESCRIPTION
Content type was throwing error when `video_type` was set to "Audio only". 
This rectifies this, not 100% sure if it's better, but it's better than a dump.
I assume there is a `downloaded_video_codec` aswell, we could use that and split it accordingly (OPUS/VP9) - let me know how you'd prefer to handle this.