### PR TITLE
<audio>-player instead of <video> for audio only

### DIFF
--- a/tubesync/sync/templates/sync/media-item.html
+++ b/tubesync/sync/templates/sync/media-item.html
@@ -10,9 +10,14 @@
     <p class="truncate"><strong><a href="{{ media.url }}" target="_blank"><i class="fas fa-link"></i> {{ media.url }}</a></strong></p>
     <p class="truncate">Downloading to: <strong>{{ media.source.directory_path }}</strong></p>
     {% if download_state == 'downloaded' %}
+    {% if media.source.is_audio %}
+    <audio controls src="{% url 'sync:media-content' pk=media.pk %}"></audio>
+    {% else %}
     <video controls style="width: 100%">
       <source src="{% url 'sync:media-content' pk=media.pk %}">
     </video>
+    {% endif %}
+
     <p class="truncate"><a href="{% url 'sync:media-content' pk=media.pk %}" download="{{ media.filename }}"><strong><i class="fas fa-download"></i> Download</strong></a></p>
     {% endif %}
   </div>


### PR DESCRIPTION
Strictly speaking you *can* use the `<video>` player for `<audio>`, but it creates a huge gap and makes preview pretty badly usable IMHO.

![image](https://user-images.githubusercontent.com/761911/218281169-229ec3f3-a874-4480-9e39-e71cca9d5c92.png)

instead of:

![image](https://user-images.githubusercontent.com/761911/218281217-4f887b39-8090-4839-88c7-2b8d8d7f97ae.png)

(yes, this is a cosmetic change; low prio)