### PR TITLE
(dev only) allow file download directly from django

### DIFF
--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -1,8 +1,10 @@
 import os
 import json
 from base64 import b64decode
+import pathlib
+import sys
 from django.conf import settings
-from django.http import FileResponse, Http404
+from django.http import FileResponse, Http404, HttpResponseNotFound
 from django.views.generic import TemplateView, ListView, DetailView
 from django.views.generic.edit import (FormView, FormMixin, CreateView, UpdateView,
                                        DeleteView)
@@ -677,13 +679,8 @@ class MediaContent(DetailView):
 
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
-        headers = {
-            'Content-Type': self.object.content_type,
-            'X-Accel-Redirect': self.object.media_file.url,
-        }
-
         # development direct file stream - DO NOT USE PRODUCTIVLY
-        if settings.PROVIDE_FILES_DIRECTLY:
+        if settings.DEBUG and 'runserver' in sys.argv:
             # get media URL
             pth = self.object.media_file.url
             # remove "/media-data/"
@@ -696,15 +693,23 @@ class MediaContent(DetailView):
                 pth = pth[1]
             else:
                 pth = pth[0]
-
+            
+            
             # build final path
-            filepth = str(settings.DOWNLOAD_ROOT) + "/" + pth
-
-            # return file
-            response = FileResponse(open(filepth,'rb'))
-            return response
+            filepth = pathlib.Path(str(settings.DOWNLOAD_ROOT) + pth)
+            
+            if filepth.exists():
+                # return file
+                response = FileResponse(open(filepth,'rb'))
+                return response
+            else:
+                return HttpResponseNotFound()
             
         else:
+            headers = {
+                'Content-Type': self.object.content_type,
+                'X-Accel-Redirect': self.object.media_file.url,
+            }
             return HttpResponse(headers=headers)
 
 

--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -2,7 +2,7 @@ import os
 import json
 from base64 import b64decode
 from django.conf import settings
-from django.http import Http404
+from django.http import FileResponse, Http404
 from django.views.generic import TemplateView, ListView, DetailView
 from django.views.generic.edit import (FormView, FormMixin, CreateView, UpdateView,
                                        DeleteView)
@@ -681,7 +681,31 @@ class MediaContent(DetailView):
             'Content-Type': self.object.content_type,
             'X-Accel-Redirect': self.object.media_file.url,
         }
-        return HttpResponse(headers=headers)
+
+        # development direct file stream - DO NOT USE PRODUCTIVLY
+        if settings.PROVIDE_FILES_DIRECTLY:
+            # get media URL
+            pth = self.object.media_file.url
+            # remove "/media-data/"
+            pth = pth.split("/media-data/",1)[1]
+            # remove "/" (incase of absolute path)
+            pth = pth.split(str(settings.DOWNLOAD_ROOT).lstrip("/"),1)
+
+            # if we do not have a "/" at the beginning, it is not a absolute path...
+            if len(pth) > 1:
+                pth = pth[1]
+            else:
+                pth = pth[0]
+
+            # build final path
+            filepth = str(settings.DOWNLOAD_ROOT) + "/" + pth
+
+            # return file
+            response = FileResponse(open(filepth,'rb'))
+            return response
+            
+        else:
+            return HttpResponse(headers=headers)
 
 
 class TasksView(ListView):


### PR DESCRIPTION
```This is a development change only - no changes on prod!```
... also requires setting `PROVIDE_FILES_DIRECTLY = True` in `local_settings.py` .

With this change, the entire package can be self-contained to test and develop without using a `docker` or `devcontainers` container.

