### PR TITLE
"Sync now" button

### DIFF
--- a/tubesync/common/static/styles/fontawesome/_icons.scss
+++ b/tubesync/common/static/styles/fontawesome/_icons.scss
@@ -65,6 +65,7 @@ readers do not read off random characters that represent icons */
 .#{$fa-css-prefix}-arrows-alt-h:before { content: fa-content($fa-var-arrows-alt-h); }
 .#{$fa-css-prefix}-arrows-alt-v:before { content: fa-content($fa-var-arrows-alt-v); }
 .#{$fa-css-prefix}-artstation:before { content: fa-content($fa-var-artstation); }
+.#{$fa-css-prefix}-arrow-rotate-right:before { content: fa-content($fa-var-arrow-rotate-right); }
 .#{$fa-css-prefix}-assistive-listening-systems:before { content: fa-content($fa-var-assistive-listening-systems); }
 .#{$fa-css-prefix}-asterisk:before { content: fa-content($fa-var-asterisk); }
 .#{$fa-css-prefix}-asymmetrik:before { content: fa-content($fa-var-asymmetrik); }

--- a/tubesync/common/static/styles/fontawesome/_variables.scss
+++ b/tubesync/common/static/styles/fontawesome/_variables.scss
@@ -80,6 +80,7 @@ $fa-var-arrow-right: \f061;
 $fa-var-arrow-up: \f062;
 $fa-var-arrows-alt: \f0b2;
 $fa-var-arrows-alt-h: \f337;
+$fa-var-arrow-rotate-right: \f01e;
 $fa-var-arrows-alt-v: \f338;
 $fa-var-artstation: \f77a;
 $fa-var-assistive-listening-systems: \f2a2;

--- a/tubesync/common/static/styles/tubesync.scss
+++ b/tubesync/common/static/styles/tubesync.scss
@@ -17,3 +17,13 @@ html {
     visibility: visible;
     opacity: 1;
 }
+
+.flex-collection-container {
+    display: flex !important;
+    align-items: center;
+}
+
+.flex-grow {
+    flex-grow: 1;
+}
+  

--- a/tubesync/sync/templates/sync/sources.html
+++ b/tubesync/sync/templates/sync/sources.html
@@ -24,15 +24,18 @@
   <div class="col s12">
     <div class="collection">
     {% for source in sources %}
-      <a href="{% url 'sync:source' pk=source.pk %}" class="collection-item">
-        {{ source.icon|safe }} <strong>{{ source.name }}</strong> ({{ source.get_source_type_display }} &quot;{{ source.key }}&quot;)<br>
-        {{ source.format_summary }}<br>
-        {% if source.has_failed %}
-        <span class="error-text"><i class="fas fa-exclamation-triangle"></i> <strong>Source has permanent failures</strong></span>
-        {% else %}
-        <strong>{{ source.media_count }}</strong> media items, <strong>{{ source.downloaded_count }}</strong> downloaded{% if source.delete_old_media and source.days_to_keep > 0 %}, keeping {{ source.days_to_keep }} days of media{% endif %}
-        {% endif %}
-      </a>
+      <span class="collection-item flex-collection-container">
+        <a href="{% url 'sync:source' pk=source.pk %}" class="flex-grow">
+          {{ source.icon|safe }} <strong>{{ source.name }}</strong> ({{ source.get_source_type_display }} &quot;{{ source.key }}&quot;)<br>
+          {{ source.format_summary }}<br>
+          {% if source.has_failed %}
+          <span class="error-text"><i class="fas fa-exclamation-triangle"></i> <strong>Source has permanent failures</strong></span>
+          {% else %}
+          <strong>{{ source.media_count }}</strong> media items, <strong>{{ source.downloaded_count }}</strong> downloaded{% if source.delete_old_media and source.days_to_keep > 0 %}, keeping {{ source.days_to_keep }} days of media{% endif %}
+          {% endif %}
+        </a>
+        <a href="{% url 'sync:source-sync-now' pk=source.pk %}" class="collection-item"><i class="fas fa-arrow-rotate-right"></i></a>
+      </span>
     {% empty %}
       <span class="collection-item no-items"><i class="fas fa-info-circle"></i> You haven't added any sources.</span>
     {% endfor %}

--- a/tubesync/sync/templates/sync/tasks.html
+++ b/tubesync/sync/templates/sync/tasks.html
@@ -66,7 +66,7 @@
       {% for task in scheduled %}
         <a href="{% url task.url pk=task.instance.pk %}" class="collection-item">
           <i class="fas fa-stopwatch"></i> <strong>{{ task }}</strong><br>
-          {% if task.instance.index_schedule %}Scheduled to run {{ task.instance.get_index_schedule_display|lower }}.<br>{% endif %}
+          {% if task.instance.index_schedule and task.repeat > 0 %}Scheduled to run {{ task.instance.get_index_schedule_display|lower }}.<br>{% endif %}
           <i class="fas fa-redo"></i> Task will run {% if task.run_now %}<strong>immediately</strong>{% else %}at <strong>{{ task.run_at|date:'Y-m-d H:i:s' }}</strong>{% endif %}
         </a>
       {% empty %}

--- a/tubesync/sync/urls.py
+++ b/tubesync/sync/urls.py
@@ -28,6 +28,10 @@ urlpatterns = [
          ValidateSourceView.as_view(),
          name='validate-source'),
 
+    path('source-sync-now/<uuid:pk>',
+         SourcesView.as_view(),
+         name='source-sync-now'),
+
     path('source-add',
          AddSourceView.as_view(),
          name='add-source'),


### PR DESCRIPTION
This PR adds a nifty litte "Sync" button that schedules a reindex.
![image](https://user-images.githubusercontent.com/761911/218328716-0476afc9-437d-4b03-9350-f8b3bdbae8c6.png)

I did *not* create a new View(class) for this, I only split the get() path into "sync" and "not sync".
I hope this is fine by you  @meeb ? If not please let me know and I will try to create a new View for it.

Also, this fixes a weird bug that kept showing that a task is "reoccuring" alltho it's "repeat" property is set to 0 in the task overview. Let me know if I shall split that into 2 PRs.

Also includes the additional "arrow-rotate-right" from FontAwesome, for some reason that one wasn't in the SCSS? 🤔 
It's not a "PRO" icon, so I'm just a bit confused if this is just a `lite` version of FA.

Also, this changes the CSS of the `container-item` into a `flex` container. If you want to avoid doing this, let me know, and I'll replace it with a <a href> below the table item, or move the action into the SourceEditView as a button.

(This was actually the main thing why I wanted to change the code here in the first place, talking about being distracted 🤣 )
