### PR TITLE
align (i) better with text (+ checkbox less wide)

### DIFF
--- a/tubesync/common/static/styles/materializecss/components/forms/_checkboxes.scss
+++ b/tubesync/common/static/styles/materializecss/components/forms/_checkboxes.scss
@@ -14,7 +14,7 @@
   // Text Label Style
   + span:not(.lever) {
     position: relative;
-    padding-left: 35px;
+    padding-left: 27px;
     cursor: pointer;
     display: inline-block;
     height: 25px;

--- a/tubesync/common/static/styles/tubesync.scss
+++ b/tubesync/common/static/styles/tubesync.scss
@@ -26,4 +26,7 @@ html {
 .flex-grow {
     flex-grow: 1;
 }
-  
+
+.help-text > i {
+    padding-right: 6px;
+}


### PR DESCRIPTION
Make the (i) less stuck to the text.

before:
![image](https://user-images.githubusercontent.com/761911/218863191-52440995-6949-4d42-9c3b-8fbdc05946e6.png)

after:
![image](https://user-images.githubusercontent.com/761911/218863101-add6a65e-8066-441b-bb38-20407167c6bb.png)


(yes, this is another feature I work on in the 1st screenshot, sorry, I only had that screenshot on hand right now.)
(also, yes, this is cosmetic, so low priority) 🔽 