### PR TITLE
chore: bump ffmpeg to `109977-gaca7ef78cc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:bullseye-slim
 
 ARG TARGETPLATFORM
 ARG S6_VERSION="3.1.2.1"
-ARG FFMPEG_DATE="autobuild-2023-02-17-12-59"
-ARG FFMPEG_VERSION="109874-gaeceefa622"
+ARG FFMPEG_DATE="autobuild-2023-03-09-12-59"
+ARG FFMPEG_VERSION="109977-gaca7ef78cc"
 
 ENV DEBIAN_FRONTEND="noninteractive" \
   HOME="/root" \
@@ -27,8 +27,8 @@ RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
   "linux/arm64")   echo "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-aarch64.tar.xz" ;; \
   *)               echo ""        ;; esac) && \
   export FFMPEG_EXPECTED_SHA256=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "f855e481b78aed625eb729e7a53bb7e84e07f76ab64c8bf48a30e631f88e2ff5" ;; \
-  "linux/arm64")   echo "9439235e4db6dcd99685d3c51223413e4f89f25e27f7aa7fe17a53c1a3d3ca9f" ;; \
+  "linux/amd64")   echo "1c01ca54acbb41fc9f850873b49edcdf8b6b6a9e6cfe17ae077826c99b849912" ;; \
+  "linux/arm64")   echo "3891a5c4dc73933067cc31e5c68de2b7033e982354ba82d247ebeb18d5e9afcc" ;; \
   *)               echo ""        ;; esac) && \
   export FFMPEG_DOWNLOAD=$(case ${TARGETPLATFORM:-linux/amd64} in \
   "linux/amd64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/${FFMPEG_DATE}/ffmpeg-N-${FFMPEG_VERSION}-linux64-gpl.tar.xz"   ;; \


### PR DESCRIPTION
`autobuild-2023-02-17-12-59 :: 109874-gaeceefa622` is not available anymore which is why the Docker build process fails.

=> https://github.com/yt-dlp/FFmpeg-Builds/releases