### PR TITLE
fix: bold font weight

### DIFF
--- a/tubesync/common/static/styles/_fonts.scss
+++ b/tubesync/common/static/styles/_fonts.scss
@@ -1,19 +1,19 @@
 @font-face {
-    font-family: 'roboto-light';
+    font-family: 'roboto';
     src: url('../fonts/roboto/roboto-light.woff') format('woff');
-    font-weight: normal;
+    font-weight: lighter;
     font-style: normal;
 }
 
 @font-face {
-    font-family: 'roboto-regular';
+    font-family: 'roboto';
     src: url('../fonts/roboto/roboto-regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
-    font-family: 'roboto-bold';
+    font-family: 'roboto';
     src: url('../fonts/roboto/roboto-bold.woff') format('woff');
     font-weight: bold;
     font-style: normal;

--- a/tubesync/common/static/styles/_variables.scss
+++ b/tubesync/common/static/styles/_variables.scss
@@ -1,2 +1,2 @@
-$font-family: 'roboto-regular', Arial, Helvetica, sans-serif;
+$font-family: 'roboto', Arial, Helvetica, sans-serif;
 $font-size: 1.05rem;


### PR DESCRIPTION
Texts which had the `font-weight` set to `bold` were displayed in normal thickness (*chromium based - macOS*).
I renamed the font-family `roboto-{light,medium,bold}` to just `roboto`, which should automatically select the correct font-family based on font-weight.

---

<details>
  <summary>Before</summary>

![Screenshot 2023-03-10 at 14 36 07](https://user-images.githubusercontent.com/71837281/224336075-7a58532a-02e7-49ec-80e1-c2fc67931d98.png)

</details>

<details>
  <summary>After</summary>

![Screenshot 2023-03-10 at 15 02 55](https://user-images.githubusercontent.com/71837281/224336247-3783feec-2b26-4597-a0e2-f2c507971111.png)

</details>


