### PR TITLE
compress sync_media table for mariadb

### DIFF
--- a/docs/other-database-backends.md
+++ b/docs/other-database-backends.md
@@ -81,7 +81,8 @@ you are now using an external database server for your TubeSync data!
 
 ## Database Compression (For MariaDB)
 With a lot of media files the `sync_media` table grows in size quickly.
-You can save space using column compression while using MariaDB
+You can save space using column compression using the following steps while using MariaDB:
+
  1. Stop tubesync 
  2. Execute `ALTER TABLE sync_source MODIFY metadata LONGTEXT COMPRESSED;` on database tubesync
  3. Start tunesync and confirm the connection still works.

--- a/docs/other-database-backends.md
+++ b/docs/other-database-backends.md
@@ -79,6 +79,13 @@ entry in the container or stdout logs:
 If you see a line similar to the above and the web interface loads, congratulations,
 you are now using an external database server for your TubeSync data!
 
+## Database Compression (For MariaDB)
+With a lot of media files the `sync_media` table grows in size quickly.
+You can save space using column compression while using MariaDB
+ 1. Stop tubesync 
+ 2. Execute `ALTER TABLE sync_source MODIFY metadata LONGTEXT COMPRESSED;` on database tubesync
+ 3. Start tunesync and confirm the connection still works.
+
 ## Docker Compose
 
 If you're using Docker Compose and simply want to connect to another container with
@@ -117,6 +124,7 @@ database before it can be written to. This file should contain:
 ```
 CREATE DATABASE tubesync;
 ```
+
 
 Then it must be mapped to `/docker-entrypoint-initdb.d/init.sql` for it
 to be executed on first startup of the container. See the `tubesync-db`


### PR DESCRIPTION
Ran into large database table sizes after importing a large channel and noticed it was the sync_source which is storing the entire metadata file content for some reason.

Not sure if thats used later at some point so just modified the database to compress the column instead.
Tested and works with Mariadb but assume the same would work for mysql as well.