### PR TITLE
Added season and episode tags in NFO to get Jellyfin displaying correctly

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1269,6 +1269,21 @@ class Media(models.Model):
         showtitle.text = str(self.source.name).strip()
         showtitle.tail = '\n  '
         nfo.append(showtitle)
+        # season = upload date year
+        season = nfo.makeelement('season', {})
+        if self.source.source_type == Source.SOURCE_TYPE_YOUTUBE_PLAYLIST:
+            # If it's a playlist, set season to 1
+            season.text = '1'
+        else:
+            # If it's not a playlist, set season to upload date year
+            season.text = str(self.upload_date.year) if self.upload_date else ''
+        season.tail = '\n  '
+        nfo.append(season)
+        # episode = number of video in the year
+        episode = nfo.makeelement('episode', {})
+        episode.text = str(self.calculate_episode_number())  # Remplacez par la logique de calcul
+        episode.tail = '\n  '
+        nfo.append(episode)
         # ratings = media metadata youtube rating
         value = nfo.makeelement('value', {})
         value.text = str(self.rating)
@@ -1392,6 +1407,38 @@ class Media(models.Model):
             raise Exception(f'Media with source type f"{self.source.source_type}" '
                             f'has no indexer')
         return indexer(self.url)
+
+    def calculate_episode_number(self):
+        filtered_media = Media.objects.filter(source=self.source)
+        if self.source.source_type == Source.SOURCE_TYPE_YOUTUBE_PLAYLIST:
+            # Calculate the episode number based on the position in the playlist
+            position_counter = 1
+
+            for media in filtered_media:
+                if media == self:
+                    return position_counter
+                position_counter += 1
+        else:
+            # Sort the filtered media by upload_date in ascending order and video ID
+            sorted_media = sorted(filtered_media, key=lambda x: (x.upload_date, x.id))
+
+            # Initialize an episode counter by year
+            episode_counter = {}
+
+            self_year = self.upload_date.year if self.upload_date else self.created.year
+
+            for media in sorted_media:
+                year = media.upload_date.year
+                if year not in episode_counter:
+                    # If it's the first video of the year, initialize the counter to 1
+                    episode_counter[year] = 1
+                else:
+                    # If it's not the first video of the year, use the current counter
+                    episode_counter[year] += 1
+
+                # Assign the calculated episode number to the media
+                if media == self:
+                    return episode_counter[self_year]
 
 
 class MediaServer(models.Model):

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -661,6 +661,8 @@ class MediaTestCase(TestCase):
             '<episodedetails>',
             '  <title>no fancy stuff title</title>',
             '  <showtitle>testname</showtitle>',
+            '  <season>2020</season>',
+            '  <episode>1</episode>',
             '  <ratings>',
             '    <rating default="True" max="5" name="youtube">',
             '      <value>1.2345</value>',


### PR DESCRIPTION
Following #379 :
For Jellyfin to get information to sort the videos, I added the season and episode tags in the NFO file:

The season is always 1 if the source is a playlist and is the year of publication if the source is a channel

The episode is the position in the playlist or the number of the video in the year, sorted by publication date if the source is a channel

I tested it with a Docker container and found that it worked correctly but I couldn't run the test script so I changed the expected NFO without having it verified