### PR TITLE
[ISSUE-468] Fix infinite error when accessing an invalid video which is already downloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 Pipfile.lock
 .vscode/launch.json
+
+# Jetbrains
+.idea

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -172,7 +172,7 @@ def media_post_save(sender, instance, created, **kwargs):
         instance.save()
         post_save.connect(media_post_save, sender=Media)
     # If the media is missing metadata schedule it to be downloaded
-    if not instance.metadata:
+    if not instance.metadata and (instance.can_download and not instance.skip):
         log.info(f'Scheduling task to download metadata for: {instance.url}')
         verbose_name = _('Downloading metadata for "{}"')
         download_media_metadata(

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -235,7 +235,14 @@ def download_media_metadata(media_id):
         log.info(f'Task for ID: {media_id} skipped, due to task being manually skipped.')
         return
     source = media.source
-    metadata = media.index_metadata()
+
+    try:
+        metadata = media.index_metadata()
+    except Exception as e:
+        media.can_download = False
+        media.skip = True
+        media.save()
+        return
     media.metadata = json.dumps(metadata, default=json_serial)
     upload_date = media.upload_date
     # Media must have a valid upload date


### PR DESCRIPTION
### Issue
- #468 

### Descrption
- When accessing an invalid video which is already downloaded
  - Mark as can not downloadable, skippable. then save.
- This may occur in the following cases:
  - 1) Add source and sync all media.
  - 2) Youtube creator changed specific video to private.
  - 3) Re-sync media source (like metadata..)
  - 4) Background task is not resolved

### References
- n/a