### PR TITLE
Adding auth option for healthcheck

### DIFF
--- a/tubesync/healthcheck.py
+++ b/tubesync/healthcheck.py
@@ -12,24 +12,38 @@
 
 import sys
 import requests
-
+import os
 
 TIMEOUT = 5  # Seconds
 
-
-def do_heatlhcheck(url):
+def do_heatlhcheck(url, username, password):
     headers = {'User-Agent': 'healthcheck'}
-    response = requests.get(url, headers=headers, timeout=TIMEOUT)
+    if username and password:
+        response = requests.get(url, headers=headers, timeout=TIMEOUT, auth=(username, password))
+    else:
+        response = requests.get(url, headers=headers, timeout=TIMEOUT)
     return response.status_code == 200
+
+def get_http_auth():
+    if "HTTP_USER" in os.environ:
+        # Attempt to get the value of the environment variable
+        username = os.environ["HTTP_USER"]
+        password = os.environ["HTTP_PASS"]
+    else:
+        username = False 
+        password = False
+    return username, password
 
 
 if __name__ == '__main__':
+    username, password = get_http_auth()
     try:
         url = sys.argv[1]
     except IndexError:
         sys.stderr.write('URL must be supplied\n')
         sys.exit(1)
-    if do_heatlhcheck(url):
+
+    if do_heatlhcheck(url, username, password):
         sys.exit(0)
     else:
         sys.exit(1)


### PR DESCRIPTION
Its grabbing the HTTP_USER and PASSWORD env variables and using them for authentication for the healthcheck.
Currently it fails if the auth is enabled, marking the container as unhealthy.

Tested with both set and unset variables.