### PR TITLE
Adding HTTP auth

### DIFF
--- a/tubesync/healthcheck.py
+++ b/tubesync/healthcheck.py
@@ -1,35 +1,32 @@
-#!/usr/bin/env python3
-'''
-
-    Perform an HTTP request to a URL and exit with an exit code of 1 if the
-    request did not return an HTTP/200 status code.
-
-    Usage:
-    $ ./healthcheck.py http://some.url.here/healthcheck/resource
-
-'''
-
-
+import os
 import sys
 import requests
 
+def health_check(url):
+    # Retrieve HTTP basic auth credentials from environment variables
+    user = os.getenv('HTTP_USER')
+    password = os.getenv('HTTP_PASS')
 
-TIMEOUT = 5  # Seconds
-
-
-def do_heatlhcheck(url):
-    headers = {'User-Agent': 'healthcheck'}
-    response = requests.get(url, headers=headers, timeout=TIMEOUT)
-    return response.status_code == 200
-
-
-if __name__ == '__main__':
     try:
-        url = sys.argv[1]
-    except IndexError:
-        sys.stderr.write('URL must be supplied\n')
+        if user and password:
+            response = requests.get(url, auth=(user, password))
+        else:
+            response = requests.get(url)
+
+        # Check if the response code is 200
+        if response.status_code == 200:
+            print("Health check passed!")
+        else:
+            print(f"Health check failed! Received status code: {response.status_code}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Health check failed! Exception: {str(e)}")
         sys.exit(1)
-    if do_heatlhcheck(url):
-        sys.exit(0)
-    else:
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python healthcheck.py <URL>")
         sys.exit(1)
+    
+    url = sys.argv[1]
+    health_check(url)

--- a/tubesync/healthcheck.py
+++ b/tubesync/healthcheck.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+'''
+
+    Perform an HTTP request to a URL and exit with an exit code of 1 if the
+    request did not return an HTTP/200 status code.
+
+    Usage:
+    $ ./healthcheck.py http://some.url.here/healthcheck/resource
+
+'''
+
 import os
 import sys
 import requests
@@ -25,7 +36,7 @@ def health_check(url):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python healthcheck.py <URL>")
+        print("Usage: python3 healthcheck.py <URL>")
         sys.exit(1)
     
     url = sys.argv[1]


### PR DESCRIPTION
Its grabbing the HTTP_USER and PASS env variables and using them for authentication for the healthcheck.
Currently it fails if the auth is enabled, marking the container as unhealthy.

Tested with both set and unset variables.

After I opened https://github.com/meeb/tubesync/pull/471 and got disgusted with it, I asked chatgpt to write one instead...