### PR TITLE
Docker build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 README.md
 tubesync/media
 tubesync/downloads
+db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,19 +100,17 @@ RUN set -x && \
   apt-get update && \
   # Install required build packages
   apt-get -y --no-install-recommends install \
-  python3-pip \
-  python3-dev \
-  gcc \
-  g++ \
-  make \
-  pkgconf \
   default-libmysqlclient-dev \
-  postgresql-common \
-  libpq-dev \
-  libjpeg62-turbo \
+  g++ \
+  gcc \
   libjpeg-dev \
-  zlib1g-dev \
+  libpq-dev \
   libwebp-dev \
+  make \
+  postgresql-common \
+  python3-dev \
+  python3-pip \
+  zlib1g-dev \
   && \
   # Create a 'app' user which the application will run as
   groupadd app && \
@@ -123,17 +121,18 @@ RUN set -x && \
   rm /app/Pipfile && \
   pipenv --clear && \
   apt-get -y autoremove --purge \
-  python3-pip \
-  python3-dev \
-  gcc \
-  g++ \
-  make \
   default-libmysqlclient-dev \
-  postgresql-common \
-  libpq-dev \
+  g++ \
+  gcc \
   libjpeg-dev \
+  libpq-dev \
+  libwebp-dev \
+  make \
+  postgresql-common \
+  python3-dev \
+  python3-pip \
   zlib1g-dev \
-  libwebp-dev && \
+  && \
   apt-get -y autoremove && \
   apt-get -y autoclean && \
   rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ occurring, typical ones are file permission issues.
 Alternatively, for Docker Compose, you can use something like:
 
 ```yml
-version: '3.7'
 services:
   tubesync:
     image: ghcr.io/meeb/tubesync:latest


### PR DESCRIPTION
Split installation of services, dependency installation, and code building steps so we can make the most use of docker build caches. When only making changes to code, this can now use the build cache to build an image in <10s. This means that if the base dependencies (redis/nginx etc) don't change between versions, the changed layers to download are less, allowing for quicker updates.

This also makes it easy to see runtime deps vs build only deps, so we can uninstall the packages we don't need once the pipenv is setup.

Dive report on ghcr.io/meeb/tubesync:latest with 10 layers
```
Total Image size: 621 MB             
Potential wasted space: 26 MB                  
Image efficiency score: 96 %
```

Dive report with these changes, with 12 layers, but quicker rebuild time, and also improved space efficiency
```
Total Image size: 603 MB                       
Potential wasted space: 8.1 MB         
Image efficiency score: 98 %
```