### PR TITLE
Fix python version in manage.py

### DIFF
--- a/tubesync/manage.py
+++ b/tubesync/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import os


### PR DESCRIPTION
```shell
root@tubesync-6c8bb86b79-s88cd:/app# /usr/bin/env python
/usr/bin/env: ‘python’: No such file or directory

root@tubesync-6c8bb86b79-s88cd:/app# /usr/bin/env python3
Python 3.11.2 (main, May  2 2024, 11:59:08) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```