### PR TITLE
Configure minimum permitted video height with VIDEO_HEIGHT_CUTOFF env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,13 +368,14 @@ useful if you are manually installing TubeSync in some other environment. These 
 | TUBESYNC_DEBUG              | Enable debugging                                             | True                                 |
 | TUBESYNC_WORKERS            | Number of background workers, default is 2, max allowed is 8 | 2                                    |
 | TUBESYNC_HOSTS              | Django's ALLOWED_HOSTS, defaults to `*`                      | tubesync.example.com,otherhost.com   |
-| TUBESYNC_RESET_DOWNLOAD_DIR | Toggle resetting `/downloads` permissions, defaults to True  | True
+| TUBESYNC_RESET_DOWNLOAD_DIR | Toggle resetting `/downloads` permissions, defaults to True  | True                                 |
 | GUNICORN_WORKERS            | Number of gunicorn workers to spawn                          | 3                                    |
 | LISTEN_HOST                 | IP address for gunicorn to listen on                         | 127.0.0.1                            |
 | LISTEN_PORT                 | Port number for gunicorn to listen on                        | 8080                                 |
 | HTTP_USER                   | Sets the username for HTTP basic authentication              | some-username                        |
 | HTTP_PASS                   | Sets the password for HTTP basic authentication              | some-secure-password                 |
 | DATABASE_CONNECTION         | Optional external database connection details                | mysql://user:pass@host:port/database |
+| VIDEO_HEIGHT_CUTOFF         | Smallest video height in pixels permitted to download        | 240                                  |
 
 
 # Manual, non-containerised, installation

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -150,8 +150,8 @@ MEDIA_THUMBNAIL_WIDTH = 430                 # Width in pixels to resize thumbnai
 MEDIA_THUMBNAIL_HEIGHT = 240                # Height in pixels to resize thumbnails to
 
 
-VIDEO_HEIGHT_CUTOFF = 240       # Smallest resolution in pixels permitted to download
-VIDEO_HEIGHT_IS_HD = 500        # Height in pixels to count as 'HD'
+VIDEO_HEIGHT_CUTOFF = int(os.getenv("VIDEO_HEIGHT_CUTOFF", "240"))  # Smallest resolution in pixels permitted to download
+VIDEO_HEIGHT_IS_HD = 500                                            # Height in pixels to count as 'HD'
 
 
 YOUTUBE_DL_CACHEDIR = None


### PR DESCRIPTION
"Get next best resolution or codec instead" has a minimum quality capped by `VIDEO_HEIGHT_CUTOFF` with no method to bypass it. This is undesirable when adding a Playlist source, where audio-only is not desired, but that would be the only way to trigger a download.

Allow video heights down to 120px to allow "next best" to fallback as far as necessary.

Possible better ways to resolve this:

- Have a configuration in the Source to define the lowest tolerable resolution (optionally allowing audio-only fallback)
- Expose a page in the webapp that allows global configuration, would require settings persistence to db

Both of these possibilities seem potentially desirable, but are much larger scope than this patch. If there's appetite, I may be willing to take on one of those projects.