### PR TITLE
Reworked Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 
 # Install third party software
 # Reminder: the SHELL handles all variables
-RUN set -ux && decide_arch() { \
+RUN decide_arch() { \
       case "${TARGETARCH:=amd64}" in \
         (arm64) printf 'aarch64' ;; \
         (*) printf '%s' "${TARGETARCH}" ;; \
@@ -60,8 +60,10 @@ RUN set -ux && decide_arch() { \
       done ; \
     } && \
     download_expected_file() { \
+      printf -- '%s\n' \
+        "Building for arch: ${2}|${ARCH}, downloading ${1} from: $(decide_url "${1}" "${2}"), expecting ${1} SHA256: $(decide_expected "${1}" "${2}")" && \
       curl -sSL --output "${3}" "$(decide_url "${1}" "${2}")" && \
-      verify_download "$(decide_expected "${1}" "${2}")" \
+      verify_download "$(decide_expected "${1}" "${2}")" "${3}" ; \
     } && \
   export ARCH="$(decide_arch)" && \
   export FFMPEG_EXPECTED_SHA256=$(case ${TARGETPLATFORM:-linux/amd64} in \
@@ -72,7 +74,6 @@ RUN set -ux && decide_arch() { \
   "linux/amd64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/${FFMPEG_DATE}/ffmpeg-N-${FFMPEG_VERSION}-linux64-gpl.tar.xz"   ;; \
   "linux/arm64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/${FFMPEG_DATE}/ffmpeg-N-${FFMPEG_VERSION}-linuxarm64-gpl.tar.xz" ;; \
   *)               echo ""        ;; esac) && \
-  echo "Building for arch: ${ARCH}|${ARCH44}, downloading S6 from: ${S6_DOWNLOAD}}, expecting S6 SHA256: ${S6_EXPECTED_SHA256}" && \
   set -x && \
   apt-get update && \
   apt-get -y --no-install-recommends install locales && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM debian:bookworm-slim
 
+ARG TARGETARCH
 ARG TARGETPLATFORM
+
 ARG S6_VERSION="3.2.0.0"
 ARG FFMPEG_DATE="autobuild-2024-10-30-14-17"
 ARG FFMPEG_VERSION="117674-g44a0a0c050"
+
+ENV S6_VERSION="${S6_VERSION}" \
+  FFMPEG_DATE="${FFMPEG_DATE}" \
+  FFMPEG_VERSION="${FFMPEG_VERSION}"
 
 ENV DEBIAN_FRONTEND="noninteractive" \
   HOME="/root" \
@@ -14,10 +20,9 @@ ENV DEBIAN_FRONTEND="noninteractive" \
   S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0"
 
 # Install third party software
-RUN export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
-  "linux/amd64")   echo "amd64"  ;; \
-  "linux/arm64")   echo "aarch64" ;; \
-  *)               echo ""        ;; esac) && \
+RUN export ARCH="$(case "${TARGETARCH:-amd64}" in \
+  arm64) echo 'aarch64' ;; \
+  *)     echo "${TARGETARCH:-amd64}" ;; esac)" && \
   export S6_ARCH_EXPECTED_SHA256=$(case ${TARGETPLATFORM:-linux/amd64} in \
   "linux/amd64")   echo "ad982a801bd72757c7b1b53539a146cf715e640b4d8f0a6a671a3d1b560fe1e2" ;; \
   "linux/arm64")   echo "868973e98210257bba725ff5b17aa092008c9a8e5174499e38ba611a8fc7e473" ;; \


### PR DESCRIPTION
Moved the hashes to build arguments.
Optimized the build by removing an unnecessary tar command.
Recorded the versions in the final container.
Used shell functions to remove repeated similar commands.
Used a copy of `/root` in `/tmp` instead of recreating it.
Cleaned up old unset variables.

I'm unsure why `ARCH` is being used, so I kept it. Using `TARGETARCH` instead makes more sense to me. Also, `ARCH44` was a complete mystery variable to me, so I removed it.

I'd suggest squashing these commits when you merge this. I was working through the website, so they are more like save points than discrete changes.