### PR TITLE
Sort video formats by height and bitrate

### DIFF
--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -87,7 +87,7 @@ def get_best_video_format(media):
         return False, False
     # Filter video-only formats by resolution that matches the source
     video_formats = []
-    sort_keys = [('height', False), ('id', False)] # key, reverse
+    sort_keys = [('height', False), ('vcodec', True), ('vbr', False)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has an audio stream, skip it
         if fmt['acodec'] is not None:
@@ -120,6 +120,10 @@ def get_best_video_format(media):
     source_resolution = media.source.source_resolution.strip().upper()
     source_vcodec = media.source.source_vcodec
     exact_match, best_match = None, None
+    for fmt in video_formats:
+        # format_note was blank, match height instead
+        if '' == fmt['format'] and fmt['height'] == media.source.source_resolution_height:
+            fmt['format'] = source_resolution
     # Of our filtered video formats, check for resolution + codec + hdr + fps match
     if media.source.prefer_60fps and media.source.prefer_hdr:
         for fmt in video_formats:

--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -57,10 +57,10 @@ def get_best_audio_format(media):
         if not fmt['acodec']:
             continue
         audio_formats.append(fmt)
-    audio_formats = list(reversed(audio_formats))
     if not audio_formats:
         # Media has no audio formats at all
         return False, False
+    audio_formats = list(reversed(audio_formats))
     # Find the first audio format with a matching codec
     for fmt in audio_formats:
         if media.source.source_acodec == fmt['acodec']:
@@ -113,12 +113,12 @@ def get_best_video_format(media):
         else:
             # Can't fallback
             return False, False
-    video_formats = multi_key_sort(video_formats, sort_keys, True)
-    source_resolution = media.source.source_resolution.strip().upper()
-    source_vcodec = media.source.source_vcodec
     if not video_formats:
         # Still no matches
         return False, False
+    video_formats = multi_key_sort(video_formats, sort_keys, True)
+    source_resolution = media.source.source_resolution.strip().upper()
+    source_vcodec = media.source.source_vcodec
     exact_match, best_match = None, None
     # Of our filtered video formats, check for resolution + codec + hdr + fps match
     if media.source.prefer_60fps and media.source.prefer_hdr:

--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -5,6 +5,7 @@
 '''
 
 
+from .utils import multi_key_sort
 from django.conf import settings
 
 
@@ -49,6 +50,7 @@ def get_best_audio_format(media):
     '''
     # Order all audio-only formats by bitrate
     audio_formats = []
+    sort_keys = [('abr', True)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has a video stream, skip it
         if fmt['vcodec'] is not None:
@@ -56,7 +58,7 @@ def get_best_audio_format(media):
         if not fmt['acodec']:
             continue
         audio_formats.append(fmt)
-    audio_formats = list(reversed(sorted(audio_formats, key=lambda k: k['abr'])))
+    audio_formats = list(multi_key_sort(audio_formats, sort_keys))
     if not audio_formats:
         # Media has no audio formats at all
         return False, False
@@ -86,6 +88,7 @@ def get_best_video_format(media):
         return False, False
     # Filter video-only formats by resolution that matches the source
     video_formats = []
+    sort_keys = [('height', True), ('id', True)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has an audio stream, skip it
         if fmt['acodec'] is not None:
@@ -109,7 +112,7 @@ def get_best_video_format(media):
         else:
             # Can't fallback
             return False, False
-    video_formats = list(reversed(sorted(video_formats, key=lambda k: k['height'])))
+    video_formats = list(multi_key_sort(video_formats, sort_keys))
     source_resolution = media.source.source_resolution.strip().upper()
     source_vcodec = media.source.source_vcodec
     if not video_formats:

--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -50,7 +50,7 @@ def get_best_audio_format(media):
     '''
     # Order all audio-only formats by bitrate
     audio_formats = []
-    sort_keys = [('abr', True)] # key, reverse
+    sort_keys = [('abr', False)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has a video stream, skip it
         if fmt['vcodec'] is not None:
@@ -58,7 +58,7 @@ def get_best_audio_format(media):
         if not fmt['acodec']:
             continue
         audio_formats.append(fmt)
-    audio_formats = list(multi_key_sort(audio_formats, sort_keys))
+    audio_formats = multi_key_sort(audio_formats, sort_keys, True)
     if not audio_formats:
         # Media has no audio formats at all
         return False, False
@@ -88,7 +88,7 @@ def get_best_video_format(media):
         return False, False
     # Filter video-only formats by resolution that matches the source
     video_formats = []
-    sort_keys = [('height', True), ('id', True)] # key, reverse
+    sort_keys = [('height', False), ('id', False)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has an audio stream, skip it
         if fmt['acodec'] is not None:
@@ -112,7 +112,7 @@ def get_best_video_format(media):
         else:
             # Can't fallback
             return False, False
-    video_formats = list(multi_key_sort(video_formats, sort_keys))
+    video_formats = multi_key_sort(video_formats, sort_keys, True)
     source_resolution = media.source.source_resolution.strip().upper()
     source_vcodec = media.source.source_vcodec
     if not video_formats:

--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -22,7 +22,7 @@ def get_best_combined_format(media):
     '''
     for fmt in media.iter_formats():
         # Check height matches
-        if media.source.source_resolution.strip().upper() != fmt['format']:
+        if media.source.source_resolution_height != fmt['height']:
             continue
         # Check the video codec matches
         if media.source.source_vcodec != fmt['vcodec']:
@@ -96,6 +96,8 @@ def get_best_video_format(media):
         if not fmt['vcodec']:
             continue
         if media.source.source_resolution.strip().upper() == fmt['format']:
+            video_formats.append(fmt)
+        elif media.source.source_resolution_height == fmt['height']:
             video_formats.append(fmt)
     # Check we matched some streams
     if not video_formats:

--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -48,9 +48,8 @@ def get_best_audio_format(media):
         Finds the best match for the source required audio format. If the source
         has a 'fallback' of fail this can return no match.
     '''
-    # Order all audio-only formats by bitrate
+    # Reverse order all audio-only formats
     audio_formats = []
-    sort_keys = [('abr', False)] # key, reverse
     for fmt in media.iter_formats():
         # If the format has a video stream, skip it
         if fmt['vcodec'] is not None:
@@ -58,18 +57,18 @@ def get_best_audio_format(media):
         if not fmt['acodec']:
             continue
         audio_formats.append(fmt)
-    audio_formats = multi_key_sort(audio_formats, sort_keys, True)
+    audio_formats = list(reversed(audio_formats))
     if not audio_formats:
         # Media has no audio formats at all
         return False, False
-    # Find the highest bitrate audio format with a matching codec
+    # Find the first audio format with a matching codec
     for fmt in audio_formats:
         if media.source.source_acodec == fmt['acodec']:
             # Matched!
             return True, fmt['id']
     # No codecs matched
     if media.source.can_fallback:
-        # Can fallback, find the next highest bitrate non-matching codec
+        # Can fallback, find the next non-matching codec
         return False, audio_formats[0]['id']
     else:
         # Can't fallback

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import math
+from operator import itemgetter
 from pathlib import Path
 import requests
 from PIL import Image
@@ -132,6 +133,15 @@ def seconds_to_timestr(seconds):
    minutes = seconds // 60
    seconds %= 60
    return '{:02d}:{:02d}:{:02d}'.format(hour, minutes, seconds)
+
+
+def multi_key_sort(sort_dict, specs, use_reversed=False):
+    result = list(sort_dict)
+    for key, reverse in reversed(specs):
+        result = sorted(result, key=itemgetter(key), reverse=reverse)
+    if use_reversed:
+        return list(reversed(result))
+    return result
 
 
 def parse_media_format(format_dict):

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -158,6 +158,8 @@ def parse_media_format(format_dict):
         vcodec = None
     if vcodec == 'NONE':
         vcodec = None
+    if vcodec == 'VP09':
+        vcodec = 'VP9'
     acodec_full = format_dict.get('acodec', '')
     acodec_parts = acodec_full.split('.')
     if len(acodec_parts) > 0:


### PR DESCRIPTION
* Stop sorting audio formats
The list we received from `youtube-dl` is better than bitrate sorting

* Include candidates by height, not format (`format_note`)
* Populate the empty format when the height matched
* Match `VP09` to `VP9` to avoid unnecessary fallback