### PR TITLE
Handle raise_no_formats exception

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1499,7 +1499,16 @@ class Media(models.Model):
         if not callable(indexer):
             raise Exception(f'Media with source type f"{self.source.source_type}" '
                             f'has no indexer')
-        return indexer(self.url)
+        response = indexer(self.url)
+        no_formats_available = (
+            not response or
+            "formats" not in response.keys() or
+            0 == len(response["formats"])
+        )
+        if no_formats_available:
+            self.can_download = False
+            self.skip = True
+        return response
 
     def calculate_episode_number(self):
         if self.source.source_type == Source.SOURCE_TYPE_YOUTUBE_PLAYLIST:

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -5,7 +5,6 @@
 
 
 import os
-import json
 from pathlib import Path
 from django.conf import settings
 from copy import copy
@@ -85,16 +84,14 @@ def _subscriber_only(msg='', response=None):
             return True
     else:
         # ignore msg entirely
-        try:
-            data = json.loads(str(response))
-        except (TypeError, ValueError, AttributeError):
-            return False
+        if not isinstance(response, dict):
+            raise TypeError(f'response must be a dict, got "{type(response)}" instead')
 
-        if 'availability' not in data.keys():
+        if 'availability' not in response.keys():
             return False
 
         # check for the specific expected value
-        return 'subscriber_only' == data.get('availability')
+        return 'subscriber_only' == response.get('availability')
     return False
 
 

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -86,7 +86,7 @@ def _subscriber_only(msg='', response=None):
     else:
         # ignore msg entirely
         try:
-            data = json.loads(response)
+            data = json.loads(str(response))
         except (TypeError, ValueError, AttributeError):
             return False
 

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -5,6 +5,7 @@
 
 
 import os
+import json
 from pathlib import Path
 from django.conf import settings
 from copy import copy
@@ -74,6 +75,28 @@ def get_channel_image_info(url):
             raise YouTubeError(f'Failed to extract channel info for "{url}": {e}') from e
 
 
+def _subscriber_only(msg='', response=None):
+    if response is None:
+        # process msg only
+        msg = str(msg)
+        if 'access to members-only content' in msg:
+            return True
+        if ': Join this channel' in msg:
+            return True
+    else:
+        # ignore msg entirely
+        try:
+            data = json.loads(response)
+        except (TypeError, ValueError, AttributeError):
+            return False
+
+        if 'availability' not in data.keys():
+            return False
+
+        # check for the specific expected value
+        return 'subscriber_only' == data.get('availability')
+    return False
+
 
 def get_media_info(url):
     '''
@@ -83,7 +106,8 @@ def get_media_info(url):
     '''
     opts = get_yt_opts()
     opts.update({
-        'ignore_no_formats_error': False,
+        'ignoreerrors': False, # explicitly set this to catch exceptions
+        'ignore_no_formats_error': False, # we must fail first to try again with this enabled
         'skip_download': True,
         'forcejson': True,
         'simulate': True,
@@ -94,13 +118,20 @@ def get_media_info(url):
     with yt_dlp.YoutubeDL(opts) as y:
         try:
             response = y.extract_info(url, download=False)
-        except yt_dlp.utils.ExtractorError as e:
-            if not e.expected:
-                raise e
-            log.warn(e.msg)
-            pass
         except yt_dlp.utils.DownloadError as e:
-            raise YouTubeError(f'Failed to extract_info for "{url}": {e}') from e
+            if not _subscriber_only(msg=e.msg):
+                raise YouTubeError(f'Failed to extract_info for "{url}": {e}') from e
+            # adjust options and try again
+            opts.update({'ignore_no_formats_error': True,})
+            with yt_dlp.YoutubeDL(opts) as yy:
+                try:
+                    response = yy.extract_info(url, download=False)
+                except yt_dlp.utils.DownloadError as ee:
+                    raise YouTubeError(f'Failed (again) to extract_info for "{url}": {ee}') from ee
+                # validate the response is what we expected
+                if not _subscriber_only(response=response):
+                    response = {}
+
     if not response:
         raise YouTubeError(f'Failed to extract_info for "{url}": No metadata was '
                            f'returned by youtube-dl, check for error messages in the '

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -83,6 +83,7 @@ def get_media_info(url):
     '''
     opts = get_yt_opts()
     opts.update({
+        'ignore_no_formats_error': False,
         'skip_download': True,
         'forcejson': True,
         'simulate': True,
@@ -93,6 +94,11 @@ def get_media_info(url):
     with yt_dlp.YoutubeDL(opts) as y:
         try:
             response = y.extract_info(url, download=False)
+        except yt_dlp.utils.ExtractorError as e:
+            if not e.expected:
+                raise e
+            log.warn(e.msg)
+            pass
         except yt_dlp.utils.DownloadError as e:
             raise YouTubeError(f'Failed to extract_info for "{url}": {e}') from e
     if not response:


### PR DESCRIPTION
Catching this and checking the message may be the best way to skip members only videos.

~My current understanding of the situation is that this won't work.~ 🙁 The documentation was inaccurate, so setting `ignoreerrors` to `False` caused the exception to be raised. 👍

I can get a better result, by setting `ignore_no_formats_error` to `True` when fetching the metadata.

Actually using that is likely to have unintended consequences in the future. I'd much rather find a way to only accept no formats for members only videos that can't be downloaded.

The next idea is to ignore the error, then parse the results to check for `"availability": "subscriber_only",` before accepting them as useful.

Fixes #584 