### PR TITLE
Only log new media

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -193,7 +193,12 @@ def index_source_task(source_id):
             media.save()
             log.debug(f'Indexed media: {source} / {media}')
             # log the new media instances
-            if media.created >= source.last_crawl:
+            new_media_instance = (
+                media.created and
+                source.last_crawl and
+                media.created >= source.last_crawl
+            )
+            if new_media_instance:
                 log.info(f'Indexed new media: {source} / {media}')
         except IntegrityError as e:
             log.error(f'Index media failed: {source} / {media} with "{e}"')

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -191,7 +191,10 @@ def index_source_task(source_id):
         media.source = source
         try:
             media.save()
-            log.info(f'Indexed media: {source} / {media}')
+            log.debug(f'Indexed media: {source} / {media}')
+            # log the new media instances
+            if media.created >= source.last_crawl:
+                log.info(f'Indexed new media: {source} / {media}')
         except IntegrityError as e:
             log.error(f'Index media failed: {source} / {media} with "{e}"')
     # Tack on a cleanup of old completed tasks


### PR DESCRIPTION
Channels with thousands of videos, that won't be downloaded, create large blocks in the logs without this.