### PR TITLE
media_file.name uses a relative path

### DIFF
--- a/tubesync/sync/management/commands/import-existing-media.py
+++ b/tubesync/sync/management/commands/import-existing-media.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             for filepath, item in filemap.items():
                 log.info(f'Matched on-disk file: {filepath} '
                          f'to media item: {item.source} / {item}')
-                item.media_file.name = filepath
+                item.media_file.name = str(Path(filepath).relative_to(item.media_file.storage.location))
                 item.downloaded = True
                 item.save()
         log.info('Done')

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -644,7 +644,7 @@ def get_media_thumb_path(instance, filename):
 
 
 def get_media_file_path(instance, filename):
-    return instance.filepath
+    return instance.filepath.relative_to(instance.media_file.storage.location)
 
 
 class Media(models.Model):


### PR DESCRIPTION
Has this worked before?

Nothing I've read has said an absolute path will work when assigned to `media_file.name` but I haven't tried it.