### PR TITLE
Match another variation of the message

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -81,6 +81,8 @@ def _subscriber_only(msg='', response=None):
             return True
         if ': Join this channel' in msg:
             return True
+        if 'Join this YouTube channel' in msg:
+            return True
     else:
         # ignore msg entirely
         if not isinstance(response, dict):


### PR DESCRIPTION
```
{key}: This video is available to this channel's members on level: Level 2: Contributor (or any higher level). Join this YouTube channel from your computer or Android app.
```