### PR TITLE
Don't chmod a+r when it already has those permissions

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -446,7 +446,11 @@ def download_media(media_id):
         # If selected, write an NFO file
         if media.source.write_nfo:
             log.info(f'Writing media NFO file to: {media.nfopath}')
-            write_text_file(media.nfopath, media.nfoxml)
+            try:
+                write_text_file(media.nfopath, media.nfoxml)
+            except PermissionError as e:
+                log.warn(f'A permissions problem occured when writing the new media NFO file: {e.msg}')
+                pass
         # Schedule a task to update media servers
         for mediaserver in MediaServer.objects.all():
             log.info(f'Scheduling media server updates')

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -123,7 +123,8 @@ def write_text_file(filepath, filedata):
         bytes_written = f.write(filedata)
     # chmod a+r temp_file
     old_mode = new_filepath.stat().st_mode
-    new_filepath.chmod(0o444 | old_mode)
+    if 0o444 != (0o444 & old_mode):
+        new_filepath.chmod(0o444 | old_mode)
     if not file_is_editable(new_filepath):
         new_filepath.unlink()
         raise ValueError(f'File cannot be edited or removed: {filepath}')


### PR DESCRIPTION
This should reduce unnecessary errors like those seen in #609.

As proposed in https://github.com/meeb/tubesync/issues/609#issuecomment-2573270228 this also logs a warning on `PermissionError` exception instead of letting that reschedule the task.