### PR TITLE
Filter metadata to avoid storing excess text in the database table

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1154,7 +1154,7 @@ class Media(models.Model):
         new_mdl = len(compact_metadata)
         if old_mdl > new_mdl:
             delta = old_mdl - new_mdl
-            log.info(f'{self.key}: metadata reduced by {delta,} characters ({old_mdl,} -> {new_mdl,})')
+            log.info(f'{self.key}: metadata reduced by {delta:,} characters ({old_mdl:,} -> {new_mdl:,})')
 
 
     @property

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1163,7 +1163,7 @@ class Media(models.Model):
             data = json.loads(self.metadata)
             if not isinstance(data, dict):
                 return {}
-            self.reduce_data(data)
+            self.reduce_data(json.loads(self.metadata))
             return data
         except Exception as e:
             return {}

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1163,7 +1163,7 @@ class Media(models.Model):
         try:
             self.reduce_data(json.loads(self.metadata))
         except Exception as e:
-            log.error(f'reduce_data: {e.msg}')
+            log.exception('reduce_data: %s', e)
             pass
 
         try:

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1174,7 +1174,8 @@ class Media(models.Model):
 
     @property
     def loaded_metadata(self):
-        self.reduce_data
+        if getattr(settings, 'SHRINK_OLD_MEDIA_METADATA', False):
+            self.reduce_data
         try:
             data = json.loads(self.metadata)
             if not isinstance(data, dict):

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1152,7 +1152,7 @@ class Media(models.Model):
 
             old_mdl = len(self.metadata or "")
             data = json.loads(self.metadata or "")
-            compact_data = json.dumps(data, separators=(',', ':'), default=json_serial)
+            compact_json = json.dumps(data, separators=(',', ':'), default=json_serial)
             
             filtered_data = filter_response(data)
             filtered_json = json.dumps(filtered_data, separators=(',', ':'), default=json_serial)
@@ -1160,7 +1160,7 @@ class Media(models.Model):
             log.exception('reduce_data: %s', e)
         else:
             # log the results of filtering / compacting on metadata size
-            new_mdl = len(compact_data)
+            new_mdl = len(compact_json)
             if old_mdl > new_mdl:
                 delta = old_mdl - new_mdl
                 log.info(f'{self.key}: metadata compacted by {delta:,} characters ({old_mdl:,} -> {new_mdl:,})')

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -19,7 +19,7 @@ from common.utils import clean_filename, clean_emoji
 from .youtube import (get_media_info as get_youtube_media_info,
                       download_media as download_youtube_media,
                       get_channel_image_info as get_youtube_channel_image_info)
-from .utils import seconds_to_timestr, parse_media_format
+from .utils import seconds_to_timestr, parse_media_format, filter_response
 from .matching import (get_best_combined_format, get_best_audio_format,
                        get_best_video_format)
 from .mediaservers import PlexMediaServer
@@ -1143,12 +1143,27 @@ class Media(models.Model):
     def has_metadata(self):
         return self.metadata is not None
 
+
+    def reduce_data(self, data):
+        from common.logger import log
+        from common.utils import json_serial
+        # log the results of filtering / compacting on metadata size
+        filtered_data = filter_response(data)
+        compact_metadata = json.dumps(filtered_data, separators=(',', ':'), default=json_serial)
+        old_mdl = len(self.metadata)
+        new_mdl = len(compact_metadata)
+        if old_mdl > new_mdl:
+            delta = old_mdl - new_mdl
+            log.info(f'{self.key}: metadata reduced by {delta,} characters ({old_mdl,} -> {new_mdl,})')
+
+
     @property
     def loaded_metadata(self):
         try:
             data = json.loads(self.metadata)
             if not isinstance(data, dict):
                 return {}
+            self.reduce_data(data)
             return data
         except Exception as e:
             return {}

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1168,6 +1168,8 @@ class Media(models.Model):
             if old_mdl > new_mdl:
                 delta = old_mdl - new_mdl
                 log.info(f'{self.key}: metadata reduced by {delta:,} characters ({old_mdl:,} -> {new_mdl:,})')
+                if getattr(settings, 'SHRINK_OLD_MEDIA_METADATA', False):
+                    self.metadata = filtered_json
 
 
     @property

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1154,7 +1154,7 @@ class Media(models.Model):
             data = json.loads(self.metadata or "")
             compact_json = json.dumps(data, separators=(',', ':'), default=json_serial)
             
-            filtered_data = filter_response(data)
+            filtered_data = filter_response(data, True)
             filtered_json = json.dumps(filtered_data, separators=(',', ':'), default=json_serial)
         except Exception as e:
             log.exception('reduce_data: %s', e)

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1159,11 +1159,17 @@ class Media(models.Model):
 
     @property
     def loaded_metadata(self):
+        from common.logger import log
+        try:
+            self.reduce_data(json.loads(self.metadata))
+        except Exception as e:
+            log.error(f'reduce_data: {e.msg}')
+            pass
+
         try:
             data = json.loads(self.metadata)
             if not isinstance(data, dict):
                 return {}
-            self.reduce_data(json.loads(self.metadata))
             return data
         except Exception as e:
             return {}

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -304,7 +304,7 @@ def download_media_metadata(media_id):
         return
     source = media.source
     metadata = media.index_metadata()
-    media.metadata = json.dumps(metadata, default=json_serial)
+    media.metadata = json.dumps(metadata, separators=(',', ':'), default=json_serial)
     upload_date = media.upload_date
     # Media must have a valid upload date
     if upload_date:

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -8,7 +8,6 @@ import os
 import json
 import math
 import uuid
-from copy import deepcopy
 from io import BytesIO
 from hashlib import sha1
 from datetime import timedelta, datetime
@@ -305,10 +304,9 @@ def download_media_metadata(media_id):
         return
     source = media.source
     metadata = media.index_metadata()
+    response = metadata
     if getattr(settings, 'SHRINK_NEW_MEDIA_METADATA', False):
-        response = filter_response(deepcopy(metadata))
-    else:
-        response = metadata
+        response = filter_response(metadata, True)
     media.metadata = json.dumps(response, separators=(',', ':'), default=json_serial)
     upload_date = media.upload_date
     # Media must have a valid upload date

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -1744,7 +1744,41 @@ class ResponseFilteringTestCase(TestCase):
 
         unfiltered = self.media.loaded_metadata
         filtered = filter_response(self.media.loaded_metadata)
-        self.assertNotEqual(len(str(unfiltered)), len(str(filtered)))
+        self.assertIn('formats', unfiltered.keys())
+        self.assertIn('formats', filtered.keys())
+        # filtered 'http_headers'
+        self.assertIn('http_headers', unfiltered['formats'][0].keys())
+        self.assertNotIn('http_headers', filtered['formats'][0].keys())
+        # did not lose any formats
+        self.assertEqual(48, len(unfiltered['formats']))
+        self.assertEqual(48, len(filtered['formats']))
+        self.assertEqual(len(unfiltered['formats']), len(filtered['formats']))
+        # did reduce the size of the metadata
+        self.assertTrue(len(str(filtered)) < len(str(unfiltered)))
+
+        url_keys = []
+        for format in unfiltered['formats']:
+            for key in format.keys():
+                if 'url' in key:
+                    url_keys.append((format['format_id'], key, format[key],))
+        unfiltered_url_keys = url_keys
+        self.assertEqual(63, len(unfiltered_url_keys), msg=str(unfiltered_url_keys))
+
+        url_keys = []
+        for format in filtered['formats']:
+            for key in format.keys():
+                if 'url' in key:
+                    url_keys.append((format['format_id'], key, format[key],))
+        filtered_url_keys = url_keys
+        self.assertEqual(3, len(filtered_url_keys), msg=str(filtered_url_keys))
+
+        url_keys = []
+        for lang_code, captions in filtered['automatic_captions'].items():
+            for caption in captions:
+                for key in caption.keys():
+                    if 'url' in key:
+                        url_keys.append((lang_code, caption['ext'], caption[key],))
+        self.assertEqual(0, len(url_keys), msg=str(url_keys))
 
 
 class TasksTestCase(TestCase):

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -1746,6 +1746,9 @@ class ResponseFilteringTestCase(TestCase):
         filtered = filter_response(self.media.loaded_metadata)
         self.assertIn('formats', unfiltered.keys())
         self.assertIn('formats', filtered.keys())
+        # filtered 'downloader_options'
+        self.assertIn('downloader_options', unfiltered['formats'][10].keys())
+        self.assertNotIn('downloader_options', filtered['formats'][10].keys())
         # filtered 'http_headers'
         self.assertIn('http_headers', unfiltered['formats'][0].keys())
         self.assertNotIn('http_headers', filtered['formats'][0].keys())
@@ -1753,6 +1756,10 @@ class ResponseFilteringTestCase(TestCase):
         self.assertEqual(48, len(unfiltered['formats']))
         self.assertEqual(48, len(filtered['formats']))
         self.assertEqual(len(unfiltered['formats']), len(filtered['formats']))
+        # did not remove everything with url
+        self.assertIn('original_url', unfiltered.keys())
+        self.assertIn('original_url', filtered.keys())
+        self.assertEqual(unfiltered['original_url'], filtered['original_url'])
         # did reduce the size of the metadata
         self.assertTrue(len(str(filtered)) < len(str(unfiltered)))
 

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -218,7 +218,7 @@ def filter_response(response_dict):
     # end of formats cleanup }}}
 
     # beginning of automatic_captions cleanup {{{
-    # drop urls that expire, or restrict IPs
+    # drop urls that expire
     def drop_auto_caption_url(**kwargs):
         url = kwargs['url']
         return (

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -213,13 +213,13 @@ def filter_response(response_dict):
             )
         )
 
-    _drop_url_keys(response_dict, 'formats', drop_format_url)
-    _drop_url_keys(response_dict, 'requested_formats', drop_format_url)
+    for key in frozenset(('formats', 'requested_formats',)):
+        _drop_url_keys(response_dict, key, drop_format_url)
     # end of formats cleanup }}}
 
-    # beginning of automatic_captions cleanup {{{
+    # beginning of subtitles cleanup {{{
     # drop urls that expire
-    def drop_auto_caption_url(**kwargs):
+    def drop_subtitles_url(**kwargs):
         url = kwargs['url']
         return (
             url
@@ -227,12 +227,13 @@ def filter_response(response_dict):
             and '&expire=' in url
         )
 
-    ac_key = 'automatic_captions'
-    if ac_key in response_dict.keys():
-        ac_dict = response_dict[ac_key]
-        for lang_code in ac_dict:
-            _drop_url_keys(ac_dict, lang_code, drop_auto_caption_url)
-    # end of automatic_captions cleanup }}}
+    # beginning of automatic_captions cleanup {{{
+    for key in frozenset(('subtitles', 'automatic_captions',)):
+        if key in response_dict.keys():
+            key_dict = response_dict[key]
+            for lang_code in key_dict:
+                _drop_url_keys(key_dict, lang_code, drop_subtitles_url)
+    # end of subtitles cleanup }}}
 
     return response_dict
 

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -176,7 +176,7 @@ def _url_keys(arg_dict, filter_func):
     for key in arg_dict.keys():
         if 'url' in key:
             result.update(
-                {key: (key, filter_func(key=key, url=arg_dict[key]),)}
+                {key: (filter_func(key=key, url=arg_dict[key]),)}
             )
     return result
 
@@ -184,9 +184,9 @@ def _url_keys(arg_dict, filter_func):
 def _drop_url_keys(arg_dict, key, filter_func):
     if key in arg_dict.keys():
         for val_dict in arg_dict[key]:
-            for url_key in _url_keys(val_dict, filter_func):
-                if url_key[1] is True:
-                    del val_dict[url_key[0]]
+            for url_key, remove in _url_keys(val_dict, filter_func).items():
+                if remove is True:
+                    del val_dict[url_key]
 
 
 def filter_response(response_dict):

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -239,7 +239,10 @@ def filter_response(response_dict):
         return (
             url
             and '://' in url
-            and '&expire=' in url
+            and (
+                '/expire/' in url
+                or '&expire=' in url
+            )
         )
 
     for key in frozenset(('subtitles', 'automatic_captions',)):

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -213,8 +213,20 @@ def filter_response(response_dict):
             )
         )
 
+    # these format keys are not useful to us
+    drop_keys = frozenset((
+        'downloader_options',
+        'fragments',
+        'http_headers',
+        '__needs_testing',
+        '__working',
+    ))
     for key in frozenset(('formats', 'requested_formats',)):
         _drop_url_keys(response_dict, key, drop_format_url)
+        if key in response_dict.keys():
+            for format in response_dict[key]:
+                for drop_key in drop_keys:
+                    del format[drop_key]
     # end of formats cleanup }}}
 
     # beginning of subtitles cleanup {{{
@@ -227,7 +239,6 @@ def filter_response(response_dict):
             and '&expire=' in url
         )
 
-    # beginning of automatic_captions cleanup {{{
     for key in frozenset(('subtitles', 'automatic_captions',)):
         if key in response_dict.keys():
             key_dict = response_dict[key]

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -170,6 +170,68 @@ def normalize_codec(codec_str):
     return result
 
 
+def _url_keys(arg_dict, filter_func):
+    result = {}
+    for key in arg_dict.keys():
+        if 'url' in key:
+            result.update(
+                {key: (key, filter_func(key=key, url=arg_dict[key]),)}
+            )
+    return result
+
+
+def _drop_url_keys(arg_dict, key, filter_func):
+    if key in arg_dict.keys():
+        for val_dict in arg_dict[key]:
+            for url_key in _url_keys(val_dict, filter_func):
+                if url_key[1] is True:
+                    del val_dict[url_key[0]]
+
+
+def filter_response(response_dict):
+    '''
+        Clean up the response so as to not store useless metadata in the database.
+    '''
+    # raise an exception for an unexpected argument type
+    if not isinstance(filedata, dict):
+        raise TypeError(f'filedata must be a dict, got "{type(filedata)}"')
+    # optimize the empty case
+    if not response_dict:
+        return response_dict
+
+    # beginning of formats cleanup {{{
+    # drop urls that expire, or restrict IPs
+    def drop_format_url(**kwargs):
+        url = kwargs['url']
+        return (
+            url
+            and '://' in url
+            and (
+                '/ip/' in url
+                or '/expire/' in url
+            )
+        )
+
+    _drop_url_keys(response_dict, 'formats', drop_format_url)
+    _drop_url_keys(response_dict, 'requested_formats', drop_format_url)
+    # end of formats cleanup }}}
+
+    # beginning of automatic_captions cleanup {{{
+    # drop urls that expire, or restrict IPs
+    def drop_auto_caption_url(**kwargs):
+        url = kwargs['url']
+        return (
+            url
+            and '://' in url
+            and '&expire=' in url
+        )
+
+    _drop_url_keys(response_dict, 'automatic_captions', drop_auto_caption_url)
+    # end of automatic_captions cleanup }}}
+
+    return response_dict
+
+
 def parse_media_format(format_dict):
     '''
         This parser primarily adapts the format dict returned by youtube-dl into a

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -194,8 +194,8 @@ def filter_response(response_dict):
         Clean up the response so as to not store useless metadata in the database.
     '''
     # raise an exception for an unexpected argument type
-    if not isinstance(filedata, dict):
-        raise TypeError(f'filedata must be a dict, got "{type(filedata)}"')
+    if not isinstance(response_dict, dict):
+        raise TypeError(f'response_dict must be a dict, got "{type(response_dict)}"')
     # optimize the empty case
     if not response_dict:
         return response_dict
@@ -227,7 +227,11 @@ def filter_response(response_dict):
             and '&expire=' in url
         )
 
-    _drop_url_keys(response_dict, 'automatic_captions', drop_auto_caption_url)
+    ac_key = 'automatic_captions'
+    if ac_key in response_dict.keys():
+        ac_dict = response_dict[ac_key]
+        for lang_code in ac_dict:
+            _drop_url_keys(ac_dict, lang_code, drop_auto_caption_url)
     # end of automatic_captions cleanup }}}
 
     return response_dict

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -226,7 +226,8 @@ def filter_response(response_dict):
         if key in response_dict.keys():
             for format in response_dict[key]:
                 for drop_key in drop_keys:
-                    del format[drop_key]
+                    if drop_key in format.keys():
+                        del format[drop_key]
     # end of formats cleanup }}}
 
     # beginning of subtitles cleanup {{{

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -176,7 +176,7 @@ def _url_keys(arg_dict, filter_func):
     for key in arg_dict.keys():
         if 'url' in key:
             result.update(
-                {key: (filter_func(key=key, url=arg_dict[key]),)}
+                {key: filter_func(key=key, url=arg_dict[key])}
             )
     return result
 
@@ -209,7 +209,9 @@ def filter_response(response_dict):
             and '://' in url
             and (
                 '/ip/' in url
+                or 'ip=' in url
                 or '/expire/' in url
+                or 'expire=' in url
             )
         )
 

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import math
+from copy import deepcopy
 from operator import itemgetter
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -189,13 +190,18 @@ def _drop_url_keys(arg_dict, key, filter_func):
                     del val_dict[url_key]
 
 
-def filter_response(response_dict):
+def filter_response(arg_dict, copy_arg=False):
     '''
         Clean up the response so as to not store useless metadata in the database.
     '''
+    response_dict = arg_dict
     # raise an exception for an unexpected argument type
     if not isinstance(response_dict, dict):
         raise TypeError(f'response_dict must be a dict, got "{type(response_dict)}"')
+
+    if copy_arg:
+        response_dict = deepcopy(arg_dict)
+
     # optimize the empty case
     if not response_dict:
         return response_dict


### PR DESCRIPTION
~These functions aren't being used yet, they will be tested against my database before that happens.~

My testing went well.

I've added two new settings to let people easily try this out.

- `SHRINK_NEW_MEDIA_METADATA` must be set to `True` for newly retrieved metadata to be filtered.

- `SHRINK_OLD_MEDIA_METADATA` must be set to `True` for loaded metadata to be updated with filtered metadata.

Please do try out whichever way is more useful for you.