### PR TITLE
Feature

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -589,7 +589,7 @@ class Source(models.Model):
             'key': 'SoMeUnIqUiD',
             'format': '-'.join(fmt),
             'playlist_title': 'Some Playlist Title',
-            'video_order': '1',
+            'video_order': '01',
             'ext': self.extension,
             'resolution': self.source_resolution if self.source_resolution else '',
             'height': '720' if self.source_resolution else '',

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1527,10 +1527,13 @@ class Media(models.Model):
 
     def get_episode_str(self, use_padding=False):
         episode_number = self.calculate_episode_number()
+        if not episode_number:
+            return ''
+
         if use_padding:
-            return f'{episode_number:02}' if episode_number else ''
+            return f'{episode_number:02}'
         
-        return str(episode_number) if episode_number else ''
+        return str(episode_number)
 
 
 class MediaServer(models.Model):

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -589,6 +589,7 @@ class Source(models.Model):
             'key': 'SoMeUnIqUiD',
             'format': '-'.join(fmt),
             'playlist_title': 'Some Playlist Title',
+            'video_order': '1',
             'ext': self.extension,
             'resolution': self.source_resolution if self.source_resolution else '',
             'height': '720' if self.source_resolution else '',
@@ -1128,6 +1129,7 @@ class Media(models.Model):
             'key': self.key,
             'format': '-'.join(display_format['format']),
             'playlist_title': self.playlist_title,
+            'video_order': self.get_episode_str(),
             'ext': self.source.extension,
             'resolution': display_format['resolution'],
             'height': display_format['height'],
@@ -1373,8 +1375,7 @@ class Media(models.Model):
         nfo.append(season)
         # episode = number of video in the year
         episode = nfo.makeelement('episode', {})
-        episode_number = self.calculate_episode_number()
-        episode.text = str(episode_number) if episode_number else ''
+        episode.text = self.get_episode_str()
         episode.tail = '\n  '
         nfo.append(episode)
         # ratings = media metadata youtube rating
@@ -1523,6 +1524,10 @@ class Media(models.Model):
             if media == self:
                 return position_counter
             position_counter += 1
+
+    def get_episode_str(self):
+        episode_number = self.calculate_episode_number()
+        return f'{episode_number:02}' if episode_number else ''
 
 
 class MediaServer(models.Model):

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1129,7 +1129,7 @@ class Media(models.Model):
             'key': self.key,
             'format': '-'.join(display_format['format']),
             'playlist_title': self.playlist_title,
-            'video_order': self.get_episode_str(),
+            'video_order': self.get_episode_str(True),
             'ext': self.source.extension,
             'resolution': display_format['resolution'],
             'height': display_format['height'],
@@ -1525,9 +1525,12 @@ class Media(models.Model):
                 return position_counter
             position_counter += 1
 
-    def get_episode_str(self):
+    def get_episode_str(self, use_padding=False):
         episode_number = self.calculate_episode_number()
-        return f'{episode_number:02}' if episode_number else ''
+        if use_padding:
+            return f'{episode_number:02}' if episode_number else ''
+        
+        return str(episode_number) if episode_number else ''
 
 
 class MediaServer(models.Model):

--- a/tubesync/sync/templates/sync/_mediaformatvars.html
+++ b/tubesync/sync/templates/sync/_mediaformatvars.html
@@ -74,6 +74,11 @@
       <td>Some Playlist</td>
     </tr>
     <tr>
+      <td>{video_order}</td>
+      <td>Episode order in playlist, if in playlist <sub><sup>(can cause issues if playlist is changed after adding)</sup></sub></td>
+      <td>01</td>
+    </tr>
+    <tr>
       <td>{ext}</td>
       <td>File extension</td>
       <td>mkv</td>


### PR DESCRIPTION
## Added feature requested in #463
- added function get_episode_str() that is basically calculating number and returning it as string with zero padding (episode 1 will be "01" etc.)
- now "Media format" can use <code>video_order</code> as episode number in file name
    - also added the new variable to "Available media name variables"