### PR TITLE
Dockerfile health check without the shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
 FROM debian:bookworm-slim
 
 ARG TARGETARCH
@@ -228,7 +231,7 @@ RUN set -x && \
 COPY config/root /
 
 # Create a healthcheck
-HEALTHCHECK --interval=1m --timeout=10s CMD /app/healthcheck.py http://127.0.0.1:8080/healthcheck
+HEALTHCHECK --interval=1m --timeout=10s --start-period=3m CMD ["/app/healthcheck.py", "http://127.0.0.1:8080/healthcheck"]
 
 # ENVS and ports
 ENV PYTHONPATH="/app" PYTHONPYCACHEPREFIX="/config/cache/pycache"


### PR DESCRIPTION
Use the form of health checking that doesn't involve an extra shell on every check.