### PR TITLE
Avoid env for healthcheck

### DIFF
--- a/tubesync/healthcheck.py
+++ b/tubesync/healthcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''
 
     Perform an HTTP request to a URL and exit with an exit code of 1 if the


### PR DESCRIPTION
This is only intended for use in containers, so we know where python3 should be installed.

This is called very often, so we should try to use as few resources as we can.