### PR TITLE
Don't write 'None' in default rating

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1426,7 +1426,8 @@ class Media(models.Model):
         rating.tail = '\n  '
         ratings = nfo.makeelement('ratings', {})
         ratings.text = '\n    '
-        ratings.append(rating)
+        if self.rating is not None:
+            ratings.append(rating)
         ratings.tail = '\n  '
         nfo.append(ratings)
         # plot = media metadata description

--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1418,7 +1418,7 @@ class Media(models.Model):
         rating_attrs = OrderedDict()
         rating_attrs['name'] = 'youtube'
         rating_attrs['max'] = '5'
-        rating_attrs['default'] = 'True'
+        rating_attrs['default'] = 'true'
         rating = nfo.makeelement('rating', rating_attrs)
         rating.text = '\n      '
         rating.append(value)


### PR DESCRIPTION
It's better to not have a rating than to create parsing problems.

An example of what is avoided:

```
<ratings>
  <rating name="youtube" max="5" default="True">
    <value>None</value>
    <votes>16781</votes>
  </rating>
</ratings>
```