### PR TITLE
Don't write zero into MPAA in .nfo

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1443,7 +1443,8 @@ class Media(models.Model):
         mpaa = nfo.makeelement('mpaa', {})
         mpaa.text = str(self.age_limit)
         mpaa.tail = '\n  '
-        nfo.append(mpaa)
+        if self.age_limit and self.age_limit > 0:
+            nfo.append(mpaa)
         # runtime = media metadata duration in seconds
         runtime = nfo.makeelement('runtime', {})
         runtime.text = str(self.duration)


### PR DESCRIPTION
It's a bit odd that `mpaa` is used in a `.nfo` that also uses TV series and episode features, but whatever.