### PR TITLE
Automated channel_id extraction

### DIFF
--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -297,11 +297,11 @@ class ValidateSourceView(FormView):
             '@' == self.key[0]
         )
         if use_channel_id:
-            source_type = self.source_type
             self.source_type_str = 'youtube-channel-id'
             self.source_type = self.source_types.get(self.source_type_str, None)
+            url = Source.create_index_url(self.source_type, self.key, 'videos')
             self.key = youtube.get_channel_id(
-                Source.create_index_url(source_type, self.key, 'videos')
+                url.replace('/channel/', '/')
             )
         for field in fields_to_populate:
             if field == 'source_type':

--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -297,10 +297,11 @@ class ValidateSourceView(FormView):
             '@' == self.key[0]
         )
         if use_channel_id:
+            source_type = self.source_type
             self.source_type_str = 'youtube-channel-id'
             self.source_type = self.source_types.get(self.source_type_str, None)
             self.key = youtube.get_channel_id(
-                Source.create_index_url(self.source_type, self.key, 'videos')
+                Source.create_index_url(source_type, self.key, 'videos')
             )
         for field in fields_to_populate:
             if field == 'source_type':

--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -291,11 +291,24 @@ class ValidateSourceView(FormView):
         url = reverse_lazy('sync:add-source')
         fields_to_populate = self.prepopulate_fields.get(self.source_type)
         fields = {}
+        value = self.key
+        use_channel_id = (
+            'youtube-channel' == self.source_type_str and
+            '@' == self.key[0]
+        )
+        if use_channel_id:
+            self.source_type_str = 'youtube-channel-id'
+            self.source_type = self.source_types.get(self.source_type_str, None)
+            self.key = youtube.get_channel_id(
+                Source.create_index_url(self.source_type, self.key, 'videos')
+            )
         for field in fields_to_populate:
             if field == 'source_type':
                 fields[field] = self.source_type
-            elif field in ('key', 'name', 'directory'):
+            elif field == 'key':
                 fields[field] = self.key
+            elif field in ('name', 'directory'):
+                fields[field] = value
         return append_uri_params(url, fields)
 
 

--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -297,12 +297,23 @@ class ValidateSourceView(FormView):
             '@' == self.key[0]
         )
         if use_channel_id:
+            old_key = self.key
+            old_source_type = self.source_type
+            old_source_type_str = self.source_type_str
+
             self.source_type_str = 'youtube-channel-id'
             self.source_type = self.source_types.get(self.source_type_str, None)
-            url = Source.create_index_url(self.source_type, self.key, 'videos')
-            self.key = youtube.get_channel_id(
-                url.replace('/channel/', '/')
-            )
+            index_url = Source.create_index_url(self.source_type, self.key, 'videos')
+            try:
+                self.key = youtube.get_channel_id(
+                    index_url.replace('/channel/', '/')
+                )
+            except youtube.YouTubeError as e:
+                # It did not work, revert to previous behavior
+                self.key = old_key
+                self.source_type = old_source_type
+                self.source_type_str = old_source_type_str
+
         for field in fields_to_populate:
             if field == 'source_type':
                 fields[field] = self.source_type

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -45,6 +45,31 @@ def get_yt_opts():
         opts.update({'cookiefile': cookie_file_path})
     return opts
 
+def get_channel_id(url):
+    # yt-dlp --simulate --no-check-formats --playlist-items 1
+    #   --print 'pre_process:%(playlist_channel_id,playlist_id,channel_id)s'
+    opts = get_yt_opts()
+    opts.update({
+        'skip_download': True,
+        'simulate': True,
+        'logger': log,
+        'extract_flat': True,  # Change to False to get detailed info
+        'check_formats': False,
+        'playlist_items': '1',
+    })
+
+    with yt_dlp.YoutubeDL(opts) as y:
+        try:
+            response = y.extract_info(url, download=False)
+            
+            channel_id = response['channel_id']
+            playlist_id = response['playlist_id']
+            playlist_channel_id = response['playlist_channel_id']
+        except yt_dlp.utils.DownloadError as e:
+            raise YouTubeError(f'Failed to extract channel ID for "{url}": {e}') from e
+        else:
+            return playlist_channel_id or playlist_id or channel_id
+
 def get_channel_image_info(url):
     opts = get_yt_opts()
     opts.update({

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -61,14 +61,15 @@ def get_channel_id(url):
     with yt_dlp.YoutubeDL(opts) as y:
         try:
             response = y.extract_info(url, download=False)
-            
-            channel_id = response['channel_id']
-            playlist_id = response['playlist_id']
-            playlist_channel_id = response['playlist_channel_id']
         except yt_dlp.utils.DownloadError as e:
             raise YouTubeError(f'Failed to extract channel ID for "{url}": {e}') from e
         else:
-            return playlist_channel_id or playlist_id or channel_id
+            try:
+                channel_id = response['channel_id']
+            except Exception as e:
+                raise YouTubeError(f'Failed to extract channel ID for "{url}": {e}') from e
+            else:
+                return channel_id
 
 def get_channel_image_info(url):
     opts = get_yt_opts()


### PR DESCRIPTION
Yay! No more manual searching for channel IDs.

It fetches the channel ID with `yt-dlp` and switches the type from channel to channel-id for the pre-filled add source page.

This is basically as described in https://github.com/meeb/tubesync/pull/306#issuecomment-1384966047

Closes #306 