### PR TITLE
Better display for audio formats

### DIFF
--- a/tubesync/sync/templates/sync/media-item.html
+++ b/tubesync/sync/templates/sync/media-item.html
@@ -146,7 +146,7 @@
           <div>
             ID: <strong>{{ format.format_id }}</strong>
             {% if format.vcodec|lower != 'none' %}, {{ format.format_note }} ({{ format.width }}x{{ format.height }}), fps:{{ format.fps|lower }}, video:{{ format.vcodec }} @{{ format.tbr }}k{% endif %}
-            {% if format.acodec|lower != 'none' %}, audio:{{ format.acodec }} @{{ format.abr }}k / {{ format.asr }}Hz{% endif %}
+            {% if format.acodec|lower != 'none' %}, audio:{{ format.acodec }} @{{ format.abr }}k / {{ format.asr }}Hz {{ format.format_note }}{% endif %}
             {% if format.format_id == combined_format or format.format_id == audio_format or format.format_id == video_format %}<strong>(matched)</strong>{% endif %}
           </div>
           {% empty %}

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -304,6 +304,7 @@ def parse_media_format(format_dict):
     return {
         'id': format_dict.get('format_id', ''),
         'format': format_str,
+        'format_note': format_dict.get('format_note', ''),
         'format_verbose': format_dict.get('format', ''),
         'height': height,
         'width': width,


### PR DESCRIPTION
The audio formats now look like this:

```
ID: 249-0, audio:opus @57.906k / 48000Hz French (France), low
ID: 249-1, audio:opus @58.154k / 48000Hz Portuguese (Brazil), low
ID: 249-2, audio:opus @58.204k / 48000Hz Spanish (United States), low
ID: 249-3, audio:opus @58.74k / 48000Hz Italian, low
ID: 250-0, audio:opus @74.628k / 48000Hz French (France), low
ID: 250-1, audio:opus @75.0k / 48000Hz Spanish (United States), low
ID: 250-2, audio:opus @75.001k / 48000Hz Portuguese (Brazil), low
ID: 250-3, audio:opus @75.602k / 48000Hz Italian, low
ID: 249-4, audio:opus @49.925k / 48000Hz English (United States) original (default), low
ID: 250-4, audio:opus @63.085k / 48000Hz English (United States) original (default), low
ID: 140-0, audio:mp4a.40.2 @129.474k / 44100Hz French (France), medium
ID: 140-1, audio:mp4a.40.2 @129.474k / 44100Hz Portuguese (Brazil), medium
ID: 140-2, audio:mp4a.40.2 @129.474k / 44100Hz Spanish (United States), medium
ID: 140-3, audio:mp4a.40.2 @129.474k / 44100Hz Italian, medium
ID: 140-4, audio:mp4a.40.2 @129.474k / 44100Hz English (United States) original (default), medium
ID: 251-0, audio:opus @142.602k / 48000Hz French (France), medium
ID: 251-1, audio:opus @143.118k / 48000Hz Spanish (United States), medium
ID: 251-2, audio:opus @143.264k / 48000Hz Portuguese (Brazil), medium
ID: 251-3, audio:opus @143.967k / 48000Hz Italian, medium
ID: 251-4, audio:opus @122.036k / 48000Hz English (United States) original (default), medium (matched)
```