### PR TITLE
Fixed where metadata files are located

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ dmypy.json
 
 Pipfile.lock
 .vscode/launch.json
+container_config
+container_downloads
 
 # Ignore Jetbrains IDE files
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 python=/usr/bin/env python
-docker=/usr/bin/docker
+docker=/usr/bin/env docker
 name=tubesync
 image=$(name):latest
 
@@ -16,6 +16,8 @@ build:
 	mkdir -p tubesync/static
 	$(python) tubesync/manage.py collectstatic --noinput
 
+migrate:
+	$(python) tubesync/manage.py migrate
 
 clean:
 	rm -rf tubesync/static
@@ -26,16 +28,34 @@ container: clean
 
 
 runcontainer:
-	$(docker) run --rm --name $(name) --env-file dev.env --log-opt max-size=50m -ti -p 4848:4848 $(image)
-
+	@if [ "$(persist)" = "true" ]; then \
+		$(docker) run --rm --name $(name) -v ./container_config:/config -v ./container_downloads:/downloads -v ./tubesync/sync/management/commands:/app/sync/management/commands --env-file dev.env --log-opt max-size=50m -ti -p 4848:4848 -d $(image); \
+		$(MAKE) container_logs;\
+	else \
+		$(docker) run --rm --name $(name) --env-file dev.env --log-opt max-size=50m -ti -p 4848:4848 $(image);\
+	fi
 
 stopcontainer:
-	$(docker) stop $(name)
+	-$(docker) stop $(name)
 
+container_logs:
+	$(docker) logs -f $(name)
+
+container_exec:
+	$(docker) exec -ti $(name) $(exec)
+
+container_manage:
+	$(docker) exec -ti $(name) python3 manage.py $(command)
 
 test: build
 	cd tubesync && $(python) manage.py test --verbosity=2 && cd ..
 
+container_rebuild: stopcontainer container runcontainer
+
+container_reset: stopcontainer container
+	rm -rf container_config
+	rm -rf container_downloads
+	$(MAKE) runcontainer persist=$(persist)
 
 shell:
 	cd tubesync && $(python) manage.py shell

--- a/docs/update-media-paths.md
+++ b/docs/update-media-paths.md
@@ -1,0 +1,40 @@
+# TubeSync
+
+## Advanced usage guide - update media paths from the command line
+
+This command allows you to all media paths. You might want to use
+this if you have renamed the Media Format for a source especially 
+if the folders are changed.
+
+
+## Requirements
+
+You have added some sources and media
+
+## Steps
+
+### 1. Run the update media paths command
+
+Execute the following Django command:
+
+`./manage.py update-media-paths`
+
+When deploying TubeSync inside a container, you can execute this with:
+
+`docker exec -ti tubesync python3 /app/manage.py update-media-paths`
+
+There are options for this command:
+* --source
+  * Only target a single source
+  * Use: `./manage.py update-media-paths --source=source_name_here`
+* --no-rename
+  * Do not rename files, only move them to another directory
+  * No value
+  * Use: `./manage.py update-media-paths --no-rename`
+* --dryrun
+  * Make no changes, only print out
+  * No value
+  * Use:  `./manage.py update-media-paths --dryrun`
+
+This command will log what its doing to the terminal when you run it.
+Highly recommended to do a dryrun and reading the log to understand what will be changed.

--- a/docs/update-media-paths.md
+++ b/docs/update-media-paths.md
@@ -2,14 +2,14 @@
 
 ## Advanced usage guide - update media paths from the command line
 
-This command allows you to all media paths. You might want to use
-this if you have renamed the Media Format for a source especially 
-if the folders are changed.
+This command updates all media paths with what is current in the database.
+This may want to be done when the Media Format has been changed for a source,
+especially if the folder structure has changed.
 
 
 ## Requirements
 
-You have added some sources and media
+At least one source and media is present
 
 ## Steps
 

--- a/tubesync/sync/management/commands/update-media-paths.py
+++ b/tubesync/sync/management/commands/update-media-paths.py
@@ -1,0 +1,82 @@
+import os
+from django.core.management.base import BaseCommand
+from common.logger import log
+from sync.models import Source, Media
+import glob
+import shutil
+
+
+class Command(BaseCommand):
+
+    help = 'Updates media when the media format has changed naming/directory'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source",
+            help="Only updates specified source"
+        )
+
+        parser.add_argument(
+            "--no-rename",
+            action="store_true",
+            help= "Do not rename the file (only move)"
+        )
+
+        parser.add_argument(
+            "--dryrun",
+            action="store_true", #treats as boolean
+            help="Don't make any changes, only print outputs"
+        )
+
+    def handle(self, *args, **options):
+        filtered_source = options['source']
+        dry_run = options['dryrun']
+        no_rename = options['no_rename']
+        if dry_run:
+            log.info('Dry run initiated')
+
+        if filtered_source:
+            log.info(f'Searching for source: {filtered_source}')
+            sources = Source.objects.filter(name=filtered_source)
+        else:
+            sources = Source.objects
+
+        for source in sources.order_by('name'):
+            log.info(f'Finding media for source: {source}')
+            for item in Media.objects.filter(source=source, downloaded=True):
+                media_path = os.path.dirname(item.media_file.path) if no_rename else item.media_file.path
+                file_path = os.path.dirname(item.filepath) if no_rename else item.filepath
+                if str(media_path) != str(file_path):
+                    log.info(media_path)
+                    log.info(file_path)
+                    log.info(f'Checking media and metadata to move: {source} / {item}')
+                    media_file_path, media_ext = os.path.splitext(os.path.basename(item.media_file.path))
+                    search_path = os.path.join(source.directory_path, '**', media_file_path)
+                    log.info(search_path)
+
+                    if not os.path.isdir(os.path.dirname(item.filepath)):
+                        os.makedirs(os.path.dirname(item.filepath))
+
+                    if no_rename:
+                        new_path = os.path.join(file_path, media_file_path)
+                    else:
+                        new_path = os.path.splitext(item.filepath)[0]
+
+                    # Find and move media
+                    for file in glob.glob(f'{search_path}.*', recursive=True):
+                        log.info(f'Matching file found: {file}')
+                        ext = "".join(file.rsplit(os.path.splitext(item.media_file.path)[0]))
+
+                        if dry_run:
+                            log.info(f'Dry Run: Moving {file} to {new_path}{ext}')
+                        else:
+                            log.info(f'Moving {file} to {new_path}{ext}')
+                            shutil.move(file, f'{new_path}{ext}')
+
+                    if dry_run:
+                        log.info(f'Dry Run: Updating db record filepath to: {new_path}{media_ext}')
+                    else:
+                        log.info(f'Updating db record filepath to: {new_path}{media_ext}')
+                        item.media_file.name = f'{new_path}{media_ext}'
+                        item.save()
+        log.info('Done')


### PR DESCRIPTION
While the `Media format` can be changed to include subfolders the location of where metadata does not. 
This PR aims to fix that and gives a fairly easy way via the cli manage script to migrate already downloaded files/metadata to the correct location when changed.
None of the existing tests fail, not sure in these tests which to modify to better test this change or if the existing tests are good enough to prove nothing is broken.


Added a task to move/rename media/metadata to match a changed "Media Format" Added a readme
Changed docker location to be more agnostic
Added a bunch of helper functions for the Makefile to aid in local development in docker (do they really belong here, is there a better place to have these?)