### PR TITLE
Default to valid JSON

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1153,7 +1153,7 @@ class Media(models.Model):
             from common.utils import json_serial
 
             old_mdl = len(self.metadata or "")
-            data = json.loads(self.metadata or "")
+            data = json.loads(self.metadata or "{}")
             compact_json = json.dumps(data, separators=(',', ':'), default=json_serial)
             
             filtered_data = filter_response(data, True)


### PR DESCRIPTION
This prevents useless logged errors when there is no metadata available yet.