### PR TITLE
Set a default nice level

### DIFF
--- a/config/root/etc/s6-overlay/s6-rc.d/tubesync-worker/run
+++ b/config/root/etc/s6-overlay/s6-rc.d/tubesync-worker/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 
-exec s6-setuidgid app \
+exec nice -n "${TUBESYNC_NICE:-1}" s6-setuidgid app \
     /usr/bin/python3 /app/manage.py process_tasks


### PR DESCRIPTION
Now that SponsorBlock is running, these jobs are using significant CPU resources.

Setting a nice level to let other things run better while `ffmpeg` is running seems wise.