### PR TITLE
Fix log.debug()

### DIFF
--- a/tubesync/tubesync/local_settings.py.container
+++ b/tubesync/tubesync/local_settings.py.container
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 from urllib.parse import urljoin
-from common.logger import log
 from common.utils import parse_database_connection_string
 
 

--- a/tubesync/tubesync/local_settings.py.container
+++ b/tubesync/tubesync/local_settings.py.container
@@ -31,7 +31,8 @@ if database_connection_env:
 
 
 if database_dict:
-    from common.logger import log
+    if not logging:
+        from common.logger import log
     log.info(f'Using database connection: {database_dict["ENGINE"]}://'
              f'{database_dict["USER"]}:[hidden]@{database_dict["HOST"]}:'
              f'{database_dict["PORT"]}/{database_dict["NAME"]}')

--- a/tubesync/tubesync/local_settings.py.container
+++ b/tubesync/tubesync/local_settings.py.container
@@ -31,6 +31,7 @@ if database_connection_env:
 
 
 if database_dict:
+    from common.logger import log
     log.info(f'Using database connection: {database_dict["ENGINE"]}://'
              f'{database_dict["USER"]}:[hidden]@{database_dict["HOST"]}:'
              f'{database_dict["PORT"]}/{database_dict["NAME"]}')


### PR DESCRIPTION
`common.logger` imports `settings`

Creating a circular dependency causes the failure to load this file from `tubesync/settings.py`.

Without the change to `DEBUG` from this file the log level is `INFO` instead of `DEBUG` so none of those messages were showing.

This was broken by 20df9f4044a3c66f641b2de145efc1b15e0ece56.