### PR TITLE
Simply add the string we want

### DIFF
--- a/tubesync/sync/templatetags/filters.py
+++ b/tubesync/sync/templatetags/filters.py
@@ -10,5 +10,5 @@ def bytesformat(input):
     output = filesizeformat(input)
     if not (output and output.endswith('B', -1)):
         return output
-    return output[: -1 ] + output[ -1 :].replace('B', 'iB', 1)
+    return output[: -1 ] + 'iB'
 


### PR DESCRIPTION
I must have been fixated on using `replace()`.
After already splitting the string, using the part we don't want seems silly.