### PR TITLE
export `TUBESYNC_RESET_DOWNLOAD_DIR`

### DIFF
--- a/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
+++ b/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
@@ -21,9 +21,9 @@ find /app -type f ! -iname healthcheck.py -exec chmod 640 {} \;
 chmod 0755 /app/healthcheck.py
 
 # Optionally reset the download dir permissions
-TUBESYNC_RESET_DOWNLOAD_DIR="${TUBESYNC_RESET_DOWNLOAD_DIR:-True}"
-if [ "$TUBESYNC_RESET_DOWNLOAD_DIR" == "True" ]
+if [ "${TUBESYNC_RESET_DOWNLOAD_DIR:=True}" == "True" ]
 then
+    export TUBESYNC_RESET_DOWNLOAD_DIR
     echo "TUBESYNC_RESET_DOWNLOAD_DIR=True, Resetting /downloads directory permissions"
     chown -R app:app /downloads
     chmod -R 0755 /downloads


### PR DESCRIPTION
We don't need to overcomplicate this.
`sh` and `bash` provide easy ways to set empty variables.

If it was exported already, doing that again won't hurt anything.

However, if we use the default because it wasn't set, we should export it or it becomes invisible after `exec` does its thing.

Not that the `manage.py` is looking for that variable or anything.