### PR TITLE
Wait for video premiere

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -353,6 +353,7 @@ def download_media_metadata(media_id):
                     verbose_name=verbose_name.format(media.key, published_datetime),
                     remove_existing_tasks=True,
                 )
+                log_exception = False
         if log_exception:
             log.exception(e)
         log.debug(str(e))

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -350,7 +350,7 @@ def download_media_metadata(media_id):
                     queue=str(media.pk),
                     repeat=Task.HOURLY,
                     repeat_until = published_datetime + timedelta(hours=2),
-                    verbose_name=verbose_name.format(media.key, published_datetime),
+                    verbose_name=verbose_name.format(media.key, published_datetime.isoformat(' ', 'seconds')),
                     remove_existing_tasks=True,
                 )
                 log_exception = False

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -345,6 +345,7 @@ def download_media_metadata(media_id):
                     repeat=Task.HOURLY,
                     repeat_until = published_datetime + timedelta(hours=2),
                     verbose_name=verbose_name.format(media.key),
+                    remove_existing_tasks=True,
                 )
         log.exception(e)
         log.debug(str(e))

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -337,6 +337,7 @@ def download_media_metadata(media_id):
                     str(media.pk),
                     priority=15,
                     queue=str(media.pk),
+                    repeat=Task.HOURLY,
                 )
         log.exception(e)
         log.debug(str(e))
@@ -567,7 +568,7 @@ def rename_all_media_for_source(source_id):
     for media in Media.objects.filter(source=source):
         media.rename_files()
 
-@background(repeat=3600, schedule=0)
+@background(schedule=0)
 def wait_for_media_premiere(media_id):
     td = lambda p, now=timezone.now(): (p - now)
     hours = lambda td: 1+int((24*td.days)+(td.seconds/(60*60)))

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -340,7 +340,7 @@ def download_media_metadata(media_id):
                 verbose_name = _('Waiting for the premiere of "{}"')
                 wait_for_media_premiere(
                     str(media.pk),
-                    priority=15,
+                    priority=0,
                     queue=str(media.pk),
                     repeat=Task.HOURLY,
                     verbose_name=verbose_name.format(media.key),

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -326,14 +326,15 @@ def download_media_metadata(media_id):
             unit = lambda p: str(p[-1]).lower()
             number = lambda p: int(str(p[-2]), base=10)
             log.debug(parts)
-            log.debug(unit(parts))
             try:
+                if 'days' == unit(parts):
+                    published_datetime = now + timedelta(days=number(parts))
+                if 'hours' == unit(parts):
+                    published_datetime = now + timedelta(hours=number(parts))
                 if 'minutes' == unit(parts):
                     published_datetime = now + timedelta(minutes=number(parts))
-                elif 'hours' == unit(parts):
-                    published_datetime = now + timedelta(hours=number(parts))
-                elif 'days' == unit(parts):
-                    published_datetime = now + timedelta(days=number(parts))
+                log.debug(unit(parts))
+                log.debug(number(parts))
             except Exception as ee:
                 log.exception(ee)
                 pass

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -349,7 +349,7 @@ def download_media_metadata(media_id):
                     priority=0,
                     queue=str(media.pk),
                     repeat=Task.HOURLY,
-                    repeat_until = published_datetime + timedelta(hours=2),
+                    repeat_until = published_datetime + timedelta(hours=1),
                     verbose_name=verbose_name.format(media.key, published_datetime.isoformat(' ', 'seconds')),
                     remove_existing_tasks=True,
                 )

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -317,7 +317,7 @@ def download_media_metadata(media_id):
         metadata = media.index_metadata()
     except YouTubeError as e:
         e_str = str(e)
-        if ': Premieres in' in e_str:
+        if ': Premieres in ' in e_str:
             now = timezone.now()
             published_datetime = None
 
@@ -325,7 +325,9 @@ def download_media_metadata(media_id):
             unit = lambda p: str(p)[-1].lower()
             number = lambda p: int(str(p)[-2], base=10)
             try:
-                if 'hours' == unit(parts):
+                if 'minutes' == unit(parts):
+                    published_datetime = now + timedelta(minutes=number(parts))
+                elif 'hours' == unit(parts):
                     published_datetime = now + timedelta(hours=number(parts))
                 elif 'days' == unit(parts):
                     published_datetime = now + timedelta(days=number(parts))


### PR DESCRIPTION
Starting on the smarter scheduling for upcoming videos.

![Screenshot_20250202-231240](https://github.com/user-attachments/assets/af22113c-79a6-49f4-96eb-ad1918ba17e6)

This quick and messy solution appears to be working. The basic approach is sound.

I would still like to edit the task name from within the task function to display the remaining hours in the task list also.


Fixes #676 