### PR TITLE
Turn off the `text-transform` with a class

### DIFF
--- a/tubesync/common/static/styles/_forms.scss
+++ b/tubesync/common/static/styles/_forms.scss
@@ -46,3 +46,7 @@ select {
         background-color: $main-button-background-hover-colour !important;
     }
 }
+
+.no-text-transform {
+    text-transform: none;
+}

--- a/tubesync/sync/templates/widgets/checkbox_option.html
+++ b/tubesync/sync/templates/widgets/checkbox_option.html
@@ -3,5 +3,5 @@
 
 <label>
     <input type="{{ option.type }}" name="{{ option.name }}" value="{{ option.value }}" id="{{ option.value }}" {% if option.selected %}checked{% endif %}>
-    <span>{{option.label}}</span>
+    <span class="no-text-transform">{{option.label}}</span>
 </label>

--- a/tubesync/sync/templates/widgets/checkbox_option.html
+++ b/tubesync/sync/templates/widgets/checkbox_option.html
@@ -1,7 +1,7 @@
 <!--<input type="{{ option.type }}" name="{{ option.name }}" value="{{ option.value }}" id="{{ option.value }}"><BR>
     <label for="{{ option.value }}">{{option.label}}</label>-->
 
-<div>
+<label>
     <input type="{{ option.type }}" name="{{ option.name }}" value="{{ option.value }}" id="{{ option.value }}" {% if option.selected %}checked{% endif %}>
     <span>{{option.label}}</span>
-</div>
+</label>


### PR DESCRIPTION
It turns out using a `div` in a06bd29f88d46eec86de071c3495d49d932f1707 broke the interface.

This is a better way.