### PR TITLE
Rework download progress hook

### DIFF
--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -43,7 +43,8 @@ def yt_dlp_progress_hook(event):
         log.error(f'[youtube-dl] error occured downloading: {filename}')
     elif 'downloading' == event['status']:
         downloaded_bytes = event.get('downloaded_bytes', 0) or 0
-        total_bytes = event.get('total_bytes', 0) or 0
+        total_bytes_estimate = event.get('total_bytes_estimate', 0) or 0
+        total_bytes = event.get('total_bytes', 0) or total_bytes_estimate
         eta = event.get('_eta_str', '?').strip()
         percent_done = event.get('_percent_str', '?').strip()
         speed = event.get('_speed_str', '?').strip()
@@ -57,6 +58,7 @@ def yt_dlp_progress_hook(event):
         else:
             # No progress to monitor, just spam every 10 download messages instead
             if 0 == hook.download_progress % 10:
+                hook.download_progress = 0
                 log.info(f'[youtube-dl] downloading: {filename} - {percent_done} '
                          f'of {total} at {speed}, {eta} remaining')
             hook.download_progress += 1

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -30,7 +30,7 @@ class PPHookStatus:
 
 def yt_dlp_progress_hook(event):
     if event['status'] not in ProgressHookStatus.valid:
-        log.warn(f'[youtube-dl] unknown event: {str(event)}')
+        log.warn(f'[youtube-dl] unknown progress event: {str(event)}')
         return None
 
     name = key = 'Unknown'
@@ -84,7 +84,7 @@ def yt_dlp_progress_hook(event):
 
 def yt_dlp_postprocessor_hook(event):
     if event['status'] not in PPHookStatus.valid:
-        log.warn(f'[youtube-dl] unknown event: {str(event)}')
+        log.warn(f'[youtube-dl] unknown postprocessor event: {str(event)}')
         return None
 
     name = key = 'Unknown'

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -29,57 +29,71 @@ class PPHookStatus:
 
 
 def yt_dlp_progress_hook(event):
-    hook = progress_hook.get('status', None)
-    if hook is None:
-        log.error('yt_dlp_progress_hook: failed to get hook status object')
-        return None
-
     if event['status'] not in ProgressHookStatus.valid:
         log.warn(f'[youtube-dl] unknown event: {str(event)}')
         return None
-
-    filename = os.path.basename(event.get('filename', '???'))
-    if 'error' == event['status']:
-        log.error(f'[youtube-dl] error occured downloading: {filename}')
-    elif 'downloading' == event['status']:
-        downloaded_bytes = event.get('downloaded_bytes', 0) or 0
-        total_bytes_estimate = event.get('total_bytes_estimate', 0) or 0
-        total_bytes = event.get('total_bytes', 0) or total_bytes_estimate
-        eta = event.get('_eta_str', '?').strip()
-        percent_done = event.get('_percent_str', '?').strip()
-        speed = event.get('_speed_str', '?').strip()
-        total = event.get('_total_bytes_str', '?').strip()
-        if downloaded_bytes > 0 and total_bytes > 0:
-            p = round(100 * downloaded_bytes / total_bytes)
-            if (0 == p % 5) and p > hook.download_progress:
-                hook.download_progress = p
-                log.info(f'[youtube-dl] downloading: {filename} - {percent_done} '
-                         f'of {total} at {speed}, {eta} remaining')
-        else:
-            # No progress to monitor, just spam every 10 download messages instead
-            if 0 == hook.download_progress % 10:
-                hook.download_progress = 0
-                log.info(f'[youtube-dl] downloading: {filename} - {percent_done} '
-                         f'of {total} at {speed}, {eta} remaining')
-            hook.download_progress += 1
-    elif 'finished' == event['status']:
-        total_size_str = event.get('_total_bytes_str', '?').strip()
-        elapsed_str = event.get('_elapsed_str', '?').strip()
-        log.info(f'[youtube-dl] finished downloading: {filename} - '
-                 f'{total_size_str} in {elapsed_str}')
-
-def yt_dlp_postprocessor_hook(event):
-    if event['status'] not in PPHookStatus.valid:
-        log.warn(f'[youtube-dl] unknown event: {str(event)}')
-        return None
-
-    postprocessor_hook['status'] = PPHookStatus(*event)
 
     name = key = 'Unknown'
     if 'display_id' in event['info_dict']:
         key = event['info_dict']['display_id']
     elif 'id' in event['info_dict']:
         key = event['info_dict']['id']
+
+    filename = os.path.basename(event.get('filename', '???'))
+    if 'error' == event['status']:
+        log.error(f'[youtube-dl] error occured downloading: {filename}')
+    elif 'downloading' == event['status']:
+        # get or create the status for key
+        status = progress_hook['status'].get(key, None)
+        if status is None:
+            progress_hook['status'].update({key: ProgressHookStatus()})
+
+        downloaded_bytes = event.get('downloaded_bytes', 0) or 0
+        total_bytes_estimate = event.get('total_bytes_estimate', 0) or 0
+        total_bytes = event.get('total_bytes', 0) or total_bytes_estimate
+        eta = event.get('_eta_str', '?').strip()
+        percent_str = event.get('_percent_str', '?').strip()
+        speed = event.get('_speed_str', '?').strip()
+        total = event.get('_total_bytes_str', '?').strip()
+        percent = None
+        try:
+            percent = int(float(percent_str.rstrip('%')))
+        except:
+            pass
+        if downloaded_bytes > 0 and total_bytes > 0:
+            percent = round(100 * downloaded_bytes / total_bytes)
+        if percent and (0 < percent) and (0 == percent % 5):
+            log.info(f'[youtube-dl] downloading: {filename} - {percent_str} '
+                     f'of {total} at {speed}, {eta} remaining')
+        status.download_progress = percent or 0
+    elif 'finished' == event['status']:
+        # update the status for key to the finished value
+        status = progress_hook['status'].get(key, None)
+        if status is None:
+            progress_hook['status'].update({key: ProgressHookStatus()})
+        status.download_progress = 100
+
+        total_size_str = event.get('_total_bytes_str', '?').strip()
+        elapsed_str = event.get('_elapsed_str', '?').strip()
+        log.info(f'[youtube-dl] finished downloading: {filename} - '
+                 f'{total_size_str} in {elapsed_str}')
+
+        # clean up the status for key
+        if key in progress_hook['status']:
+            del progress_hook['status'][key]
+
+def yt_dlp_postprocessor_hook(event):
+    if event['status'] not in PPHookStatus.valid:
+        log.warn(f'[youtube-dl] unknown event: {str(event)}')
+        return None
+
+    name = key = 'Unknown'
+    if 'display_id' in event['info_dict']:
+        key = event['info_dict']['display_id']
+    elif 'id' in event['info_dict']:
+        key = event['info_dict']['id']
+
+    postprocessor_hook['status'].update({key: PPHookStatus(*event)})
 
     title = None
     if 'fulltitle' in event['info_dict']:
@@ -98,15 +112,19 @@ def yt_dlp_postprocessor_hook(event):
         log.debug(repr(event['info_dict']))
 
     log.info(f'[{event["postprocessor"]}] {event["status"]} for: {name}')
+    if 'finished' == event['status'] and key in postprocessor_hook['status']:
+        del postprocessor_hook['status'][key]
 
 
 progress_hook = {
-    'status': ProgressHookStatus(),
+    'class': ProgressHookStatus(),
     'function': yt_dlp_progress_hook,
+    'status': dict(),
 }
 
 postprocessor_hook = {
-    'status': PPHookStatus(),
+    'class': PPHookStatus(),
     'function': yt_dlp_postprocessor_hook,
+    'status': dict(),
 }
 

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -274,6 +274,9 @@ def download_media(
 
     progress_hook_func = progress_hook.get('function', None)
     if progress_hook_func:
+        hook = progress_hook.get('status', None)
+        if hook:
+            hook.download_progress = 0
         ytopts['progress_hooks'].append(progress_hook_func)
 
     codec_options = list()

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -274,9 +274,6 @@ def download_media(
 
     progress_hook_func = progress_hook.get('function', None)
     if progress_hook_func:
-        hook = progress_hook.get('status', None)
-        if hook:
-            hook.download_progress = 0
         ytopts['progress_hooks'].append(progress_hook_func)
 
     codec_options = list()


### PR DESCRIPTION
- Be more resilient about missing keys.
- Log the downloading state the first time through.
- Keep `hook.download_progress` under 100.
- Try to use `total_bytes_estimate` when `total_bytes` is not available.

~For multiple downloads, at the same time, this needs to be improved further.
Each download will need to track status independently.~
The key may need to be adjusted, but the basic support is already present.

Reference:
```
    progress_hooks:    A list of functions that get called on download
                       progress, with a dictionary with the entries
                       * status: One of "downloading", "error", or "finished".
                                 Check this first and ignore unknown values.
                       * info_dict: The extracted info_dict

                       If status is one of "downloading", or "finished", the
                       following properties may also be present:
                       * filename: The final filename (always present)
                       * tmpfilename: The filename we're currently writing to
                       * downloaded_bytes: Bytes on disk
                       * total_bytes: Size of the whole file, None if unknown
                       * total_bytes_estimate: Guess of the eventual file size,
                                               None if unavailable.
                       * elapsed: The number of seconds since download started.
                       * eta: The estimated time in seconds, None if unknown
                       * speed: The download speed in bytes/second, None if
                                unknown
                       * fragment_index: The counter of the currently
                                         downloaded video fragment.
                       * fragment_count: The number of fragments (= individual
                                         files that will be merged)

                       Progress hooks are guaranteed to be called at least once
                       (with status "finished") if the download is successful.
```