### PR TITLE
Add & use functions from status classes

### DIFF
--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -13,6 +13,7 @@ postprocessor_hook = {
     'status': dict(),
 }
 
+
 class BaseStatus:
     valid = set()
 
@@ -54,6 +55,11 @@ class ProgressHookStatus(BaseStatus):
         self.info = info_dict
         self.status = status
         self.download_progress = 0
+
+    def next_progress(self):
+        if 0 == self.download_progress:
+            return 0
+        return 5 + self.download_progress
 
 class PPHookStatus(BaseStatus):
     valid = frozenset((
@@ -109,10 +115,10 @@ def yt_dlp_progress_hook(event):
             pass
         if downloaded_bytes > 0 and total_bytes > 0:
             percent = round(100 * downloaded_bytes / total_bytes)
-        if percent and (0 < percent) and (0 == percent % 5):
+        if percent and (self.next_progress() < percent) and (0 == percent % 5):
+            status.download_progress = percent
             log.info(f'[youtube-dl] downloading: {filename} - {percent_str} '
                      f'of {total} at {speed}, {eta} remaining')
-        status.download_progress = percent or 0
     elif 'finished' == event['status']:
         # update the status for key to the finished value
         status = ProgressHookStatus.get(key)

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -115,7 +115,7 @@ def yt_dlp_progress_hook(event):
             pass
         if downloaded_bytes > 0 and total_bytes > 0:
             percent = round(100 * downloaded_bytes / total_bytes)
-        if percent and (self.next_progress() < percent) and (0 == percent % 5):
+        if percent and (status.next_progress() < percent) and (0 == percent % 5):
             status.download_progress = percent
             log.info(f'[youtube-dl] downloading: {filename} - {percent_str} '
                      f'of {total} at {speed}, {eta} remaining')

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -5,6 +5,14 @@ from common.logger import log
 from django.conf import settings
 
 
+progress_hook = {
+    'status': dict(),
+}
+
+postprocessor_hook = {
+    'status': dict(),
+}
+
 class BaseStatus:
     valid = set()
 
@@ -158,15 +166,13 @@ def yt_dlp_postprocessor_hook(event):
         status.cleanup()
 
 
-progress_hook = {
+progress_hook.update({
     'class': ProgressHookStatus(),
     'function': yt_dlp_progress_hook,
-    'status': dict(),
-}
+})
 
-postprocessor_hook = {
+postprocessor_hook.update({
     'class': PPHookStatus(),
     'function': yt_dlp_postprocessor_hook,
-    'status': dict(),
-}
+})
 

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -102,7 +102,7 @@ def yt_dlp_progress_hook(event):
         if status is None:
             status = ProgressHookStatus(**event)
             status.register(key, filename, status.filename)
-            log.info(ProgressHookStatus.status_dict)
+            log.info(str(ProgressHookStatus.status_dict))
 
         downloaded_bytes = event.get('downloaded_bytes', 0) or 0
         total_bytes_estimate = event.get('total_bytes_estimate', 0) or 0
@@ -128,7 +128,7 @@ def yt_dlp_progress_hook(event):
         if status is None:
             status = ProgressHookStatus(**event)
             status.register(key, filename, status.filename)
-            log.info(ProgressHookStatus.status_dict)
+            log.info(str(ProgressHookStatus.status_dict))
         status.download_progress = 100
 
         total_size_str = event.get('_total_bytes_str', '?').strip()

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -59,7 +59,7 @@ class ProgressHookStatus(BaseStatus):
         self.download_progress = 0
 
     def __str__(self):
-        return f'{self.__name__}: {self.status} ({self.download_progress}) file: {self.filename}'
+        return f'{self!r}: {self.status} ({self.download_progress}) file: {self.filename}'
 
     def next_progress(self):
         if 0 == self.download_progress:

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -58,6 +58,9 @@ class ProgressHookStatus(BaseStatus):
         self.status = status
         self.download_progress = 0
 
+    def __str__(self):
+        return f'{self.__name__}: {self.status} ({self.download_progress}) file: {self.filename}'
+
     def next_progress(self):
         if 0 == self.download_progress:
             return 0
@@ -134,7 +137,6 @@ def yt_dlp_progress_hook(event):
                  f'{total_size_str} in {elapsed_str}')
 
         status.cleanup()
-        log.info(ProgressHookStatus.status_dict)
 
 def yt_dlp_postprocessor_hook(event):
     if not PPHookStatus.valid_status(event['status']):

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -13,7 +13,7 @@ class ProgressHookStatus:
     ))
 
     def valid_status(status):
-        return status in self.valid
+        return status in ProgressHookStatus.valid
 
     def get(key):
         return progress_hook['status'].get(key, None)
@@ -46,7 +46,7 @@ class PPHookStatus:
     ))
 
     def valid_status(status):
-        return status in self.valid
+        return status in PPHookStatus.valid
 
     def get(key):
         return postprocessor_hook['status'].get(key, None)

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -114,10 +114,10 @@ def yt_dlp_progress_hook(event):
             percent = int(float(percent_str.rstrip('%')))
         except:
             pass
-        if fragment_index > 0 and fragment_count > 0:
+        if fragment_index >= 0 and fragment_count > 0:
             percent = round(100 * fragment_index / fragment_count)
             percent_str = f'{percent}%'
-        elif downloaded_bytes > 0 and total_bytes > 0:
+        elif downloaded_bytes >= 0 and total_bytes > 0:
             percent = round(100 * downloaded_bytes / total_bytes)
         if percent and (status.next_progress() < percent) and (0 == percent % 5):
             status.download_progress = percent

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -116,6 +116,7 @@ def yt_dlp_progress_hook(event):
             pass
         if fragment_index > 0 and fragment_count > 0:
             percent = round(100 * fragment_index / fragment_count)
+            percent_str = f'{percent}%'
         elif downloaded_bytes > 0 and total_bytes > 0:
             percent = round(100 * downloaded_bytes / total_bytes)
         if percent and (status.next_progress() < percent) and (0 == percent % 5):

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -61,7 +61,7 @@ class ProgressHookStatus(BaseStatus):
     def next_progress(self):
         if 0 == self.download_progress:
             return 0
-        return 5 + self.download_progress
+        return 1 + self.download_progress
 
 class PPHookStatus(BaseStatus):
     status_dict = postprocessor_hook['status']

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -103,6 +103,8 @@ def yt_dlp_progress_hook(event):
         downloaded_bytes = event.get('downloaded_bytes', 0) or 0
         total_bytes_estimate = event.get('total_bytes_estimate', 0) or 0
         total_bytes = event.get('total_bytes', 0) or total_bytes_estimate
+        fragment_index = event.get('fragment_index', 0) or 0
+        fragment_count = event.get('fragment_count', 0) or 0
         eta = event.get('_eta_str', '?').strip()
         percent_str = event.get('_percent_str', '?').strip()
         speed = event.get('_speed_str', '?').strip()
@@ -114,6 +116,8 @@ def yt_dlp_progress_hook(event):
             pass
         if downloaded_bytes > 0 and total_bytes > 0:
             percent = round(100 * downloaded_bytes / total_bytes)
+        if fragment_index > 0 and fragment_count > 0:
+            percent = round(100 * fragment_index / fragment_count)
         if percent and (status.next_progress() < percent) and (0 == percent % 5):
             status.download_progress = percent
             log.info(f'[youtube-dl] downloading: {filename} - {percent_str} '

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -114,10 +114,10 @@ def yt_dlp_progress_hook(event):
             percent = int(float(percent_str.rstrip('%')))
         except:
             pass
-        if downloaded_bytes > 0 and total_bytes > 0:
-            percent = round(100 * downloaded_bytes / total_bytes)
         if fragment_index > 0 and fragment_count > 0:
             percent = round(100 * fragment_index / fragment_count)
+        elif downloaded_bytes > 0 and total_bytes > 0:
+            percent = round(100 * downloaded_bytes / total_bytes)
         if percent and (status.next_progress() < percent) and (0 == percent % 5):
             status.download_progress = percent
             log.info(f'[youtube-dl] downloading: {filename} - {percent_str} '


### PR DESCRIPTION
Now that fragments are properly reporting progress, the only slightly confusing part of the logged output is the sleep.

```
2025-02-07 21:08:49,916 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 25% of N/A at 128.42KiB/s, 00:28 remaining
2025-02-07 21:08:53,787 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 35% of N/A at 127.73KiB/s, 00:27 remaining
2025-02-07 21:08:59,072 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 45% of N/A at 81.94KiB/s, 00:30 remaining
2025-02-07 21:09:04,240 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 55% of N/A at 58.39KiB/s, 00:34 remaining
2025-02-07 21:09:09,920 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 65% of N/A at 92.47KiB/s, 00:25 remaining
2025-02-07 21:09:16,355 [tubesync/INFO] [youtube-dl] downloading: [FILE]_vp9-opus.f605.mp4 - 75% of N/A at 94.06KiB/s, 00:19 remaining
```

`yt-dlp` logs the sleeping messages with the `[download]` tag. I still need to find out if we can display only those messages or not.

Fixes #698 