### PR TITLE
Remove subtitles also

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -221,10 +221,15 @@ def media_post_delete(sender, instance, **kwargs):
         video_path = Path(str(instance.media_file.path)).resolve()
         instance.media_file.delete(save=False)
         # the other files we created have these known suffixes
-        for suffix in frozenset(('nfo', 'jpg', 'webp', 'vtt', 'info.json',)):
+        for suffix in frozenset(('nfo', 'jpg', 'webp', 'info.json',)):
             other_path = video_path.with_suffix(f'.{suffix}').resolve()
             log.info(f'Deleting file for: {instance} path: {other_path!s}')
             delete_file(other_path)
+        # subtitles include language code
+        subtitle_files = video_path.parent.glob(f'{glob_quote(video_path.with_suffix("").name)}*.vtt')
+        for file in subtitle_files:
+            log.info(f'Deleting file for: {instance} path: {file}')
+            delete_file(file)
         # Jellyfin creates .trickplay directories and posters
         for suffix in frozenset(('.trickplay', '-poster.jpg', '-poster.webp',)):
             # with_suffix insists on suffix beginning with '.' for no good reason

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -221,7 +221,7 @@ def media_post_delete(sender, instance, **kwargs):
         video_path = Path(str(instance.media_file.path)).resolve()
         instance.media_file.delete(save=False)
         # the other files we created have these known suffixes
-        for suffix in frozenset(('nfo', 'jpg', 'webp', 'info.json',)):
+        for suffix in frozenset(('nfo', 'jpg', 'webp', 'vtt', 'info.json',)):
             other_path = video_path.with_suffix(f'.{suffix}').resolve()
             log.info(f'Deleting file for: {instance} path: {other_path!s}')
             delete_file(other_path)


### PR DESCRIPTION
https://github.com/meeb/tubesync/blob/8d89cc01f961b6440584d5984784e01881dfa900/tubesync/sync/signals.py#L263-L268

I think this was already covered by `all_related_files` at the end, but matching `*.vtt` files earlier won't hurt anything.

Fixes #416