### PR TITLE
Allow `exec_cmd` dictionary to be configured in settings

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -224,6 +224,10 @@ def download_media(
         'sponskrub': False,
     })
 
+    pp_opts.exec_cmd.update(
+        opts.get('exec_cmd', default_opts.exec_cmd)
+    )
+
     if skip_sponsors:
         # Let yt_dlp convert from human for us.
         pp_opts.sponsorblock_mark = yt_dlp.parse_options(


### PR DESCRIPTION
This is a dictionary with keys of `WHEN` and values are a `list` of commands for the `ExecPP` to run.