### PR TITLE
Remove logging of the SQL

### DIFF
--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -61,11 +61,11 @@ class BaseStatus:
         else:
             mqs = mqs.exclude(
                 skip=True,
-                manual_skip=True
+                manual_skip=True,
+                downloaded=True,
             ).filter(
                 source__download_media=True,
                 can_download=True,
-                downloaded=False,
                 key=self.media_key
             )
             for m in mqs:

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -62,7 +62,7 @@ class BaseStatus:
             mqs = mqs.exclude(
                 skip=True,
                 manual_skip=True,
-                downloaded=True,
+                downloaded=True
             ).filter(
                 source__download_media=True,
                 can_download=True,

--- a/tubesync/sync/hooks.py
+++ b/tubesync/sync/hooks.py
@@ -68,7 +68,6 @@ class BaseStatus:
                 downloaded=False,
                 key=self.media_key
             )
-            log.debug(mqs.query)
             for m in mqs:
                 t = get_media_download_task(str(m.pk))
                 if t:


### PR DESCRIPTION
I've seen it, and the query looks fine.

```sql
SELECT "sync_media"."uuid", "sync_media"."created",
"sync_media"."source_id", "sync_media"."published",
"sync_media"."key", "sync_media"."thumb",
"sync_media"."thumb_width", "sync_media"."thumb_height",
"sync_media"."metadata", "sync_media"."can_download",
"sync_media"."media_file", "sync_media"."skip",
"sync_media"."manual_skip", "sync_media"."downloaded",
"sync_media"."download_date", "sync_media"."downloaded_format",
"sync_media"."downloaded_height", "sync_media"."downloaded_width",
"sync_media"."downloaded_audio_codec", "sync_media"."downloaded_video_codec",
"sync_media"."downloaded_container", "sync_media"."downloaded_fps",
"sync_media"."downloaded_hdr", "sync_media"."downloaded_filesize",
"sync_media"."duration", "sync_media"."title"
FROM "sync_media" INNER JOIN "sync_source"
ON ("sync_media"."source_id" = "sync_source"."uuid")
WHERE (
  NOT ("sync_media"."manual_skip" AND "sync_media"."skip")
  AND "sync_media"."can_download" AND
  NOT "sync_media"."downloaded" AND
  "sync_media"."key" = KEY AND
  "sync_source"."download_media"
)
```