### PR TITLE
Handle `None` in `video["duration"]`

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -213,7 +213,7 @@ def index_source_task(source_id):
         except Media.DoesNotExist:
             media = Media(key=key)
         media.source = source
-        media.duration = float(video.get(fields('duration', media), 0)) or None
+        media.duration = float(video.get(fields('duration', media), 0) or 0) or None
         media.title = str(video.get(fields('title', media), ''))[:200]
         timestamp = video.get(fields('timestamp', media), None)
         if timestamp is not None:


### PR DESCRIPTION
Translate `None` from `get` to `0` for `float`

Fixes #725