### PR TITLE
Do not turn `Media.skip` off for already skipped media

### DIFF
--- a/tubesync/sync/filtering.py
+++ b/tubesync/sync/filtering.py
@@ -12,7 +12,7 @@ from .overrides.custom_filter import filter_custom
 # Check the filter conditions for instance, return is if the Skip property has changed so we can do other things
 def filter_media(instance: Media):
     # Assume we aren't skipping it, if any of these conditions are true, we skip it
-    skip = False
+    skip = instance.skip
 
     # Check if it's published
     if not skip and filter_published(instance):

--- a/tubesync/sync/filtering.py
+++ b/tubesync/sync/filtering.py
@@ -12,7 +12,7 @@ from .overrides.custom_filter import filter_custom
 # Check the filter conditions for instance, return is if the Skip property has changed so we can do other things
 def filter_media(instance: Media):
     # Assume we aren't skipping it, if any of these conditions are true, we skip it
-    skip = instance.skip
+    skip = False
 
     # Check if it's published
     if not skip and filter_published(instance):
@@ -41,9 +41,9 @@ def filter_media(instance: Media):
 
     # Check if skipping
     if instance.skip != skip:
-        instance.skip = skip
+        instance.skip = instance.skip or skip
         log.info(
-            f"Media: {instance.source} / {instance} has changed skip setting to {skip}"
+            f"Media: {instance.source} / {instance} has changed skip setting to {instance.skip}"
         )
         return True
 

--- a/tubesync/sync/filtering.py
+++ b/tubesync/sync/filtering.py
@@ -41,6 +41,7 @@ def filter_media(instance: Media):
 
     # Check if skipping
     if instance.skip != skip:
+        # only allow; False => True changes
         instance.skip = instance.skip or skip
         log.info(
             f"Media: {instance.source} / {instance} has changed skip setting to {instance.skip}"

--- a/tubesync/sync/filtering.py
+++ b/tubesync/sync/filtering.py
@@ -40,11 +40,11 @@ def filter_media(instance: Media):
         skip = True
 
     # Check if skipping
-    if instance.skip != skip:
-        # only allow; False => True changes
-        instance.skip = instance.skip or skip
+    # only allow; False => True changes
+    if not instance.skip and False != skip:
+        instance.skip = skip
         log.info(
-            f"Media: {instance.source} / {instance} has changed skip setting to {instance.skip}"
+            f"Media: {instance.source} / {instance} has changed skip setting to {skip}"
         )
         return True
 

--- a/tubesync/sync/filtering.py
+++ b/tubesync/sync/filtering.py
@@ -41,7 +41,7 @@ def filter_media(instance: Media):
 
     # Check if skipping
     # only allow; False => True changes
-    if not instance.skip and False != skip:
+    if not instance.skip and skip:
         instance.skip = skip
         log.info(
             f"Media: {instance.source} / {instance} has changed skip setting to {skip}"

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -187,7 +187,6 @@ def media_post_save(sender, instance, created, **kwargs):
         if instance.can_download and instance.downloaded:
             skip_changed = True != instance.skip
             instance.skip = True
-        instance.media_file = None
         downloaded = False
     if (instance.source.download_media and instance.can_download) and not (
         instance.skip or downloaded or existing_media_download_task):

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -181,14 +181,16 @@ def media_post_save(sender, instance, created, **kwargs):
             )
     existing_media_download_task = get_media_download_task(str(instance.pk))
     # If the media has not yet been downloaded schedule it to be downloaded
+    downloaded = instance.downloaded
     if not (instance.media_file_exists or existing_media_download_task):
         # The file was deleted after it was downloaded, skip this media.
         if instance.can_download and instance.downloaded:
             skip_changed = True != instance.skip
             instance.skip = True
         instance.media_file = None
+        downloaded = False
     if (instance.source.download_media and instance.can_download) and not (
-        instance.skip or instance.downloaded or existing_media_download_task):
+        instance.skip or downloaded or existing_media_download_task):
         verbose_name = _('Downloading media for "{}"')
         download_media(
             str(instance.pk),

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -186,7 +186,6 @@ def media_post_save(sender, instance, created, **kwargs):
         if instance.can_download and instance.downloaded:
             skip_changed = True != instance.skip
             instance.skip = True
-        instance.downloaded = False
         instance.media_file = None
     if (instance.source.download_media and instance.can_download) and not (
         instance.skip or instance.downloaded or existing_media_download_task):

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -454,9 +454,7 @@ def download_media(media_id):
                  f'it is now marked to be skipped, not downloading')
         return
     downloaded_file_exists = (
-        media.media_file and
-        media.media_file.path and
-        media.filepath.samefile(media.media_file.path) and
+        media.media_file_exists or
         media.filepath.exists()
     )
     if media.downloaded and downloaded_file_exists:

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -453,7 +453,13 @@ def download_media(media_id):
         log.warn(f'Download task triggered for media: {media} (UUID: {media.pk}) but '
                  f'it is now marked to be skipped, not downloading')
         return
-    if media.downloaded and media.media_file and media.media_file.name:
+    downloaded_file_exists = (
+        media.media_file and
+        media.media_file.path and
+        media.filepath.samefile(media.media_file.path) and
+        media.filepath.exists()
+    )
+    if media.downloaded and downloaded_file_exists:
         # Media has been marked as downloaded before the download_media task was fired,
         # skip it
         log.warn(f'Download task triggered for media: {media} (UUID: {media.pk}) but '


### PR DESCRIPTION
~This probably needs a more nuanced solution.~

Ok. I think this handles the cases we need.

Fixes #723