### PR TITLE
Schedule a rename task per media item instead

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -13,7 +13,7 @@ from .tasks import (delete_task_by_source, delete_task_by_media, index_source_ta
                     download_media_thumbnail, download_media_metadata,
                     map_task_to_instance, check_source_directory_exists,
                     download_media, rescan_media_server, download_source_images,
-                    save_all_media_for_source, rename_all_media_for_source,
+                    save_all_media_for_source, rename_media,
                     get_media_metadata_task, get_media_download_task)
 from .utils import delete_file, glob_quote
 from .filtering import filter_media

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -73,22 +73,23 @@ def source_post_save(sender, instance, created, **kwargs):
             )
     # Check settings before any rename tasks are scheduled
     rename_sources_setting = settings.RENAME_SOURCES or list()
-    create_rename_task = (
+    create_rename_tasks = (
         (
             instance.directory and
             instance.directory in rename_sources_setting
         ) or
         settings.RENAME_ALL_SOURCES
     )
-    if create_rename_task:
-        verbose_name = _('Renaming all media for source "{}"')
-        rename_all_media_for_source(
-            str(instance.pk),
-            queue=str(instance.pk),
-            priority=1,
-            verbose_name=verbose_name.format(instance.name),
-            remove_existing_tasks=True
-        )
+    if create_rename_tasks:
+        for media in Media.objects.filter(source=instance.pk, downloaded=True):
+            verbose_name = _('Renaming media for: {}: "{}"')
+            rename_media(
+                str(media.pk),
+                queue=str(media.pk),
+                priority=1,
+                verbose_name=verbose_name.format(media.key, media.name),
+                remove_existing_tasks=True
+            )
     verbose_name = _('Checking all media for source "{}"')
     save_all_media_for_source(
         str(instance.pk),

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -51,6 +51,7 @@ def map_task_to_instance(task):
         'sync.tasks.download_media': Media,
         'sync.tasks.download_media_metadata': Media,
         'sync.tasks.save_all_media_for_source': Source,
+        'sync.tasks.rename_media': Media,
         'sync.tasks.rename_all_media_for_source': Source,
         'sync.tasks.wait_for_media_premiere': Media,
     }
@@ -574,7 +575,7 @@ def rescan_media_server(mediaserver_id):
     mediaserver.update()
 
 
-@background(schedule=0)
+@background(schedule=0, remove_existing_tasks=True)
 def save_all_media_for_source(source_id):
     '''
         Iterates all media items linked to a source and saves them to
@@ -595,7 +596,16 @@ def save_all_media_for_source(source_id):
         media.save()
 
 
-@background(schedule=0)
+@background(schedule=0, remove_existing_tasks=True)
+def rename_media(media_id):
+    try:
+        media = Media.objects.get(pk=media_id)
+    except Media.DoesNotExist:
+        return
+    media.rename_files()
+
+
+@background(schedule=0, remove_existing_tasks=True)
 def rename_all_media_for_source(source_id):
     try:
         source = Source.objects.get(pk=source_id)
@@ -607,7 +617,8 @@ def rename_all_media_for_source(source_id):
     for media in Media.objects.filter(source=source):
         media.rename_files()
 
-@background(schedule=0)
+
+@background(schedule=0, remove_existing_tasks=True)
 def wait_for_media_premiere(media_id):
     hours = lambda td: 1+int((24*td.days)+(td.seconds/(60*60)))
 


### PR DESCRIPTION
This is a user experience improvement and should also be more effective as well.

Having a task per download gives the user better insight into the progress of the renaming.

It also allows a new task to remove the queued task because the locked task no longer includes every media item.