### PR TITLE
Pin `django-background-tasks`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 autopep8 = "*"
 
 [packages]
-django = "~=3.2"
+django = "*"
 django-sass-processor = "*"
 libsass = "*"
 pillow = "*"
@@ -15,7 +15,7 @@ whitenoise = "*"
 gunicorn = "*"
 django-compressor = "*"
 httptools = "*"
-django-background-tasks = "*"
+django-background-tasks = "1.2.5"
 django-basicauth = "*"
 psycopg2-binary = "*"
 mysqlclient = "*"


### PR DESCRIPTION
It's `django-background-tasks` that limits the Django version.