### PR TITLE
Remove unnecessary `chmod` executions

### DIFF
--- a/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
+++ b/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
@@ -13,12 +13,11 @@ chown -R app:app /config
 chmod -R 0755 /config
 chown -R root:app /app
 chmod -R 0750 /app
+chmod 0755 /app/*.py /app/*.sh
+find /app -mindepth 2 -type f -execdir chmod 640 '{}' +
 chown -R app:app /app/common/static
-chmod -R 0750 /app/common/static
 chown -R app:app /app/static
-chmod -R 0750 /app/static
-find /app -type f ! -iname healthcheck.py -exec chmod 640 {} \;
-chmod 0755 /app/healthcheck.py
+
 
 # Optionally reset the download dir permissions
 if [ "${TUBESYNC_RESET_DOWNLOAD_DIR:=True}" == "True" ]

--- a/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
+++ b/config/root/etc/s6-overlay/s6-rc.d/tubesync-init/run
@@ -18,7 +18,6 @@ find /app -mindepth 2 -type f -execdir chmod 640 '{}' +
 chown -R app:app /app/common/static
 chown -R app:app /app/static
 
-
 # Optionally reset the download dir permissions
 if [ "${TUBESYNC_RESET_DOWNLOAD_DIR:=True}" == "True" ]
 then


### PR DESCRIPTION
Setting the mode to the same value twice is only wasted effort.