### PR TITLE
Prevent unintended unhealthy restarts

### DIFF
--- a/tubesync/healthcheck.py
+++ b/tubesync/healthcheck.py
@@ -30,6 +30,9 @@ def do_heatlhcheck(url):
 
 
 if __name__ == '__main__':
+    # if it is marked as intentionally down, nothing else matters
+    if os.path.exists('/run/service/gunicorn/down'):
+        sys.exit(0)
     try:
         url = sys.argv[1]
     except IndexError:


### PR DESCRIPTION
When I intentionally set a test container to be down, I really don't want it to be restarted because it was "unhealthy" for too long