### PR TITLE
Use `yt-dlp` `daterange` option

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -508,7 +508,10 @@ class Source(models.Model):
         indexer = self.INDEXERS.get(self.source_type, None)
         if not callable(indexer):
             raise Exception(f'Source type f"{self.source_type}" has no indexer')
-        response = indexer(self.get_index_url(type=type))
+        days = None
+        if self.download_cap_date:
+            days = timedelta(seconds=self.download_cap).days
+        response = indexer(self.get_index_url(type=type), days=days)
         if not isinstance(response, dict):
             return []
         entries = response.get('entries', []) 

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -130,12 +130,21 @@ def _subscriber_only(msg='', response=None):
     return False
 
 
-def get_media_info(url):
+def get_media_info(url, days=None):
     '''
         Extracts information from a YouTube URL and returns it as a dict. For a channel
         or playlist this returns a dict of all the videos on the channel or playlist
         as well as associated metadata.
     '''
+    start = None
+    if days is not None:
+        try:
+            days = int(str(days), 10)
+        except Exception as e:
+            days = None
+        start = (
+            f'yesterday-{days!s}days' if days else None
+        )
     opts = get_yt_opts()
     opts.update({
         'ignoreerrors': False, # explicitly set this to catch exceptions
@@ -145,6 +154,7 @@ def get_media_info(url):
         'logger': log,
         'extract_flat': True,
         'check_formats': True,
+        'daterange': yt_dlp.utils.DateRange(start=start),
         'extractor_args': {
             'youtube': {'formats': ['missing_pot']},
             'youtubetab': {'approximate_date': ['true']},


### PR DESCRIPTION
So, after reading #147, I thought TEDx would be a good stress test for this.

My production container using `latest` is attempting to only index that channel.

`$` [docker container stats](https://docs.docker.com/reference/cli/docker/container/stats/) `--no-stream TubeSync PostgreSQL`
```
CONTAINER ID   NAME         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
42139b7cca00   TubeSync     97.73%    5.906GiB / 31.34GiB   18.85%    306GB / 12.6GB   5.02MB / 13.8MB   31
fc7cb3bd1893   PostgreSQL   4.28%     230.4MiB / 31.34GiB   0.72%     6.19GB / 302GB   0B / 8.19kB       18
```

The test container is already done indexing the last week of videos.

```
 Index media from source "TEDx Talks"
Source: "181b3a4b-c955-41aa-bafb-0ca705fce2da"
 Task ran at 2025-02-27 16:11:06
 Checking all media for source "TEDx Talks"
Source: "None"
 Task ran at 2025-02-27 16:10:26
 Checking all media for source "TEDx Talks"
Source: "None"
 Task ran at 2025-02-27 14:35:23
 Check download directory exists for source "TEDx Talks"
Source: "None"
 Task ran at 2025-02-27 14:30:21
```

Fixes #48
Fixes #156 