### PR TITLE
Be more user-friendly when sorting tasks

### DIFF
--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -782,8 +782,8 @@ class TasksView(ListView):
         prefix = '-' if 'ASC' != order else ''
         _priority = f'{prefix}priority'
         return qs.order_by(
+            'run_at',
             _priority,
-            'run_at'
         )
 
     def get_context_data(self, *args, **kwargs):


### PR DESCRIPTION
The time first, then the priority, if the tasks are at the same time.