### PR TITLE
Restrict `PYTHONPYCACHEPREFIX` to `pipenv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,9 +297,6 @@ RUN --mount=type=tmpfs,target=/cache \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   set -x && \
-  # Remove __pycache__ directories from the image
-  PYTHONPYCACHEPREFIX=/cache/pycache && \
-  export PYTHONPYCACHEPREFIX && \
   # Update from the network and keep cache
   rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
@@ -325,6 +322,7 @@ RUN --mount=type=tmpfs,target=/cache \
   HOME="/tmp/${HOME#/}" \
   XDG_CACHE_HOME='/cache' \
   PIPENV_VERBOSITY=64 \
+  PYTHONPYCACHEPREFIX=/cache/pycache \
     pipenv install --system --skip-lock && \
   # Clean up
   apt-get -y autoremove --purge \


### PR DESCRIPTION
It turns out `apt` and friends don't play nicely with that variable.