### PR TITLE
Save and use cached `.info.json` files

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -130,7 +130,7 @@ def _subscriber_only(msg='', response=None):
     return False
 
 
-def get_media_info(url, days=None):
+def get_media_info(url, /, *, days=None, info_json=None):
     '''
         Extracts information from a YouTube URL and returns it as a dict. For a channel
         or playlist this returns a dict of all the videos on the channel or playlist
@@ -146,20 +146,36 @@ def get_media_info(url, days=None):
             f'yesterday-{days!s}days' if days else None
         )
     opts = get_yt_opts()
+    class NoDefaultValue: pass # a unique Singleton, that may be checked for later
+    user_set = lambda k, d, default=NoDefaultValue: d[k] if k in d.keys() else default
     opts.update({
         'ignoreerrors': False, # explicitly set this to catch exceptions
         'ignore_no_formats_error': False, # we must fail first to try again with this enabled
+        'overwrites': False,
         'skip_download': True,
         'simulate': True,
         'logger': log,
         'extract_flat': True,
         'check_formats': True,
+        'clean_infojson': False,
         'daterange': yt_dlp.utils.DateRange(start=start),
         'extractor_args': {
             'youtube': {'formats': ['missing_pot']},
             'youtubetab': {'approximate_date': ['true']},
         },
+        'paths': opts.get('paths', dict()),
+        'writeinfojson': user_set('writeinfojson', opts, bool(info_json)),
     })
+    try:
+        info_json_path = Path(info_json).resolve(strict=False)
+    except:
+        pass
+    else:
+        opts['paths'].update({
+            'infojson': user_set('infojson', opts['paths'], str(info_json_path))
+        })
+    if 'infojson' not in opts['paths'].keys():
+        opts.update({'writeinfojson': False})
     response = {}
     with yt_dlp.YoutubeDL(opts) as y:
         try:


### PR DESCRIPTION
The idea is to reduce the number of requests sent to YouTube.

Related to:
- #777 