### PR TITLE
Speed up `arm64` builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,6 +275,7 @@ RUN --mount=type=cache,id=apt-lib-cache,sharing=locked,target=/var/lib/apt \
   pipenv \
   pkgconf \
   python3 \
+  python3-libsass \
   python3-wheel \
   curl \
   less \


### PR DESCRIPTION
This is the dependency that takes so long to compile that it dominated every other part of the build time.

It's a ~12 MiB wheel when we compile from the latest source.