### PR TITLE
Remove explicit `libsass`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ autopep8 = "*"
 [packages]
 django = "*"
 django-sass-processor = "*"
-libsass = "*"
 pillow = "*"
 whitenoise = "*"
 gunicorn = "*"


### PR DESCRIPTION
We need this to use the package added in #808.