### PR TITLE
Create `fatal_http_errors.py` patch

### DIFF
--- a/patches/yt_dlp/patch/fatal_http_errors.py
+++ b/patches/yt_dlp/patch/fatal_http_errors.py
@@ -3,9 +3,23 @@ from yt_dlp.extractor.youtube import YoutubeIE
 
 class PatchedYoutubeIE(YoutubeIE):
 
-    def FUNC(self):
-        pass
+    def _download_player_responses(self, url, smuggled_data, video_id, webpage_url):
+        webpage = None
+        if 'webpage' not in self._configuration_arg('player_skip'):
+            query = {'bpctr': '9999999999', 'has_verified': '1'}
+            pp = self._configuration_arg('player_params', [None], casesense=True)[0]
+            if pp:
+                query['pp'] = pp
+            webpage = self._download_webpage_with_retries(webpage_url, video_id, query=query)
+
+        master_ytcfg = self.extract_ytcfg(video_id, webpage) or self._get_default_ytcfg()
+
+        player_responses, player_url = self._extract_player_responses(
+            self._get_requested_clients(url, smuggled_data),
+            video_id, webpage, master_ytcfg, smuggled_data)
+
+        return webpage, master_ytcfg, player_responses, player_url
 
 
-#YoutubeIE.__unpatched__FUNC = YoutubeIE.FUNC
-#YoutubeIE.FUNC = PatchedYoutubeIE.FUNC
+YoutubeIE.__unpatched___download_player_responses = YoutubeIE._download_player_responses
+YoutubeIE._download_player_responses = PatchedYoutubeIE._download_player_responses

--- a/patches/yt_dlp/patch/fatal_http_errors.py
+++ b/patches/yt_dlp/patch/fatal_http_errors.py
@@ -10,7 +10,7 @@ class PatchedYoutubeIE(YoutubeIE):
             pp = self._configuration_arg('player_params', [None], casesense=True)[0]
             if pp:
                 query['pp'] = pp
-            webpage = self._download_webpage_with_retries(webpage_url, video_id, query=query)
+            webpage = self._download_webpage_with_retries(webpage_url, video_id, retry_fatal=True, query=query)
 
         master_ytcfg = self.extract_ytcfg(video_id, webpage) or self._get_default_ytcfg()
 

--- a/patches/yt_dlp/patch/fatal_http_errors.py
+++ b/patches/yt_dlp/patch/fatal_http_errors.py
@@ -1,0 +1,11 @@
+from yt_dlp.extractor.youtube import YoutubeIE
+
+
+class PatchedYoutubeIE(YoutubeIE):
+
+    def FUNC(self):
+        pass
+
+
+#YoutubeIE.__unpatched__FUNC = YoutubeIE.FUNC
+#YoutubeIE.FUNC = PatchedYoutubeIE.FUNC

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -18,6 +18,7 @@ from .hooks import postprocessor_hook, progress_hook
 from .utils import mkdir_p
 import yt_dlp
 import yt_dlp.patch.check_thumbnails
+import yt_dlp.patch.fatal_http_errors
 from yt_dlp.utils import remove_end
 
 


### PR DESCRIPTION
To respect HTTP 429 errors, we need to provide additional arguments to a function called in the `YoutubeIE` class.

Fixes #849