### PR TITLE
Reduce the amount of time the database is locked

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -254,7 +254,7 @@ def media_post_save(sender, instance, created, **kwargs):
         verbose_name = _('Downloading metadata for "{}"')
         download_media_metadata(
             str(instance.pk),
-            priority=10,
+            priority=20,
             verbose_name=verbose_name.format(instance.pk),
             remove_existing_tasks=True
         )


### PR DESCRIPTION
SQLite is bad at concurrency, so we try to minimize the amount of time a transaction has the database locked to work around that limitation.

Fixes #834 