### PR TITLE
Additional extractor args for youtube

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -169,8 +169,9 @@ def get_media_info(url, days=None):
         'extractor_args': {
             'youtube': {
                 'formats': ['missing_pot'],
-                'raise_incomplete_data': ['true'],
                 'max_comments': ['1,all,all,all'],
+                'player_client': ['default', 'web_safari'],
+                'raise_incomplete_data': ['true'],
             },
             'youtubetab': {'approximate_date': ['true']},
         },


### PR DESCRIPTION
These need more testing.

The documentation is not great with these.

After reading about it in [this issue](https://github.com/yt-dlp/yt-dlp/issues/12398#issuecomment-2666894402), I need to look into another one:
`--extractor-arg "youtube:player_client=web_safari"`

The pot plugin also uses an extractor arg:
`youtube:getpot_bgutil_baseurl=http://127.0.0.1:4416`

Here is an example of setting that using the settings file instead of the `yt-dlp` flags:

```python
YOUTUBE_DEFAULTS = {
    'extractor_args': {
        'youtube': {
            'getpot_bgutil_baseurl': ['http://127.0.0.1:4416'],
            'formats': ['missing_pot'],
            'max_comments': ['1,all,all,all'],
            'player_client': ['default', 'web_safari'],
            'raise_incomplete_data': ['true'],
        },
        'youtubetab': {'approximate_date': ['true']},
    },
}
```