### PR TITLE
Change the task expiration to 1 day

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Set up Django environment
         run: |
           cp -v -p tubesync/tubesync/local_settings.py.example tubesync/tubesync/local_settings.py
+          cp -v -a -t "${Python3_ROOT_DIR}"/lib/python3.*/site-packages/background_task/ patches/background_task/*
           cp -v -a -t "${Python3_ROOT_DIR}"/lib/python3.*/site-packages/yt_dlp/ patches/yt_dlp/*
       - name: Run Django tests
         run: cd tubesync && python3 manage.py test --verbosity=2

--- a/Dockerfile
+++ b/Dockerfile
@@ -362,9 +362,8 @@ RUN --mount=type=tmpfs,target=/cache \
   apt-get -y autoclean && \
   rm -v -rf /tmp/*
 
-# Copy app
-COPY tubesync /app
-COPY tubesync/tubesync/local_settings.py.container /app/tubesync/local_settings.py
+# Copy root
+COPY config/root /
 
 # patch background_task
 COPY patches/background_task/ \
@@ -373,6 +372,10 @@ COPY patches/background_task/ \
 # patch yt_dlp
 COPY patches/yt_dlp/ \
     /usr/local/lib/python3/dist-packages/yt_dlp/
+
+# Copy app
+COPY tubesync /app
+COPY tubesync/tubesync/local_settings.py.container /app/tubesync/local_settings.py
 
 # Build app
 RUN set -x && \
@@ -387,16 +390,12 @@ RUN set -x && \
   mkdir -v -p /config/cache/pycache && \
   mkdir -v -p /downloads/audio && \
   mkdir -v -p /downloads/video && \
+  # Check nginx configuration copied from config/root/etc
+  nginx -t && \
   # Append software versions
   ffmpeg_version=$(/usr/local/bin/ffmpeg -version | awk -v 'ev=31' '1 == NR && "ffmpeg" == $1 { print $3; ev=0; } END { exit ev; }') && \
   test -n "${ffmpeg_version}" && \
   printf -- "ffmpeg_version = '%s'\n" "${ffmpeg_version}" >> /app/common/third_party_versions.py
-
-# Copy root
-COPY config/root /
-
-# Check nginx configuration copied from config/root/etc
-RUN set -x && nginx -t
 
 # Create a healthcheck
 HEALTHCHECK --interval=1m --timeout=10s --start-period=3m CMD ["/app/healthcheck.py", "http://127.0.0.1:8080/healthcheck"]

--- a/patches/background_task/models.py
+++ b/patches/background_task/models.py
@@ -49,7 +49,7 @@ class TaskManager(models.Manager):
         boot_time = self.posix_epoch
         kcore_path = Path('/proc/kcore')
         if kcore_path.exists():
-            stats = kcore_path.stats()
+            stats = kcore_path.stat()
         if stats:
             boot_time += timedelta(seconds=stats.st_mtime)
         if boot_time > self._boot_time:

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -135,7 +135,7 @@ HEALTHCHECK_ALLOWED_IPS = ('127.0.0.1',)
 
 
 MAX_ATTEMPTS = 15                           # Number of times tasks will be retried
-MAX_RUN_TIME = 1800                         # Maximum amount of time in seconds a task can run
+MAX_RUN_TIME = 1*(24*60*60)                 # Maximum amount of time in seconds a task can run
 BACKGROUND_TASK_RUN_ASYNC = True            # Run tasks async in the background
 BACKGROUND_TASK_ASYNC_THREADS = 1           # Number of async tasks to run at once
 MAX_BACKGROUND_TASK_ASYNC_THREADS = 8       # For sanity reasons


### PR DESCRIPTION
The node name for docker changes when creating a new container.

The PID can match after creating a new image if the start up sequence is the same.

~Using `docker restart` may still cause false positives for tasks still running.~

Used `boot_time` (from `/proc/kcore` mount) to determine if `locked_at` was before the current Docker start time.