### PR TITLE
Add a post-processor to disallow partial playlist results

### DIFF
--- a/tubesync/full_playlist.sh
+++ b/tubesync/full_playlist.sh
@@ -4,7 +4,7 @@ echo "$1"
 echo "$2"
 exit 0
 
-if [ "$1" -ne "$2" ]
+if [ 'NA' != "$2" ] && [ "$1" != "$2" ]
 then
     exit 1
 fi

--- a/tubesync/full_playlist.sh
+++ b/tubesync/full_playlist.sh
@@ -3,14 +3,29 @@
 playlist_id="${1}"
 total_entries="${2}"
 
-downloaded_entries="$( find / \
+# select YOUTUBE_*DIR settings
+# convert None to ''
+# convert PosixPath('VALUE') to 'VALUE'
+# assign a shell variable with the setting name and value
+_awk_prog='$2 == "=" && $1 ~ /^YOUTUBE_/ && $1 ~ /DIR$/ {
+    sub(/^None$/, "'\'\''", $3);
+    r = sub(/^PosixPath[(]/, "", $3);
+    NF--;
+    if(r) {sub(/[)]$/, "", $NF);};
+    $3=$1 $2 $3; $1=$2=""; sub("^" OFS "+", "");
+    print;
+    }'
+. <(python3 /app/manage.py diffsettings --output hash | awk "${_awk_prog}")
+WHERE="${YOUTUBE_DL_CACHEDIR:-/dev/shm}"
+
+downloaded_entries="$( find /dev/shm "${WHERE}" \
     -path '*/infojson/playlist/postprocessor_*_temp\.info\.json' \
     -name "postprocessor_[[]${playlist_id}[]]_*_${total_entries}_temp\.info\.json" \
     -exec basename '{}' ';' | \
     sed -e 's/^postprocessor_[[].*[]]_//;s/_temp.*\.json$//;' | \
     cut -d '_' -f 1 )"
 
-find / \
+find /dev/shm "${WHERE}" \
     -path '*/infojson/playlist/postprocessor_*_temp\.info\.json' \
     -name "postprocessor_[[]${playlist_id}[]]_*_temp\.info\.json" \
     -type f -delete

--- a/tubesync/full_playlist.sh
+++ b/tubesync/full_playlist.sh
@@ -1,18 +1,23 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-echo "$1"
-echo "$2"
 playlist_id="${1}"
 total_entries="${2}"
-set -x
 
-time find / -path '*/infojson/playlist/*' \
-    -name "postprocessor_[${playlist_id}]_*_${total_entries}_temp.info.json"
+downloaded_entries="$( find / \
+    -path '*/infojson/playlist/postprocessor_*_temp\.info\.json' \
+    -name "postprocessor_[[]${playlist_id}[]]_*_${total_entries}_temp\.info\.json" \
+    -exec basename '{}' ';' | \
+    sed -e 's/^postprocessor_[[].*[]]_//;s/_temp.*\.json$//;' | \
+    cut -d '_' -f 1 )"
 
-exit 0
-downloaded_entries=0
+find / \
+    -path '*/infojson/playlist/postprocessor_*_temp\.info\.json' \
+    -name "postprocessor_[[]${playlist_id}[]]_*_temp\.info\.json" \
+    -type f -delete
 
-if [ 'NA' != "${total_entries}" ] && [ "${downloaded_entries}" != "${total_entries}" ]
+if  [ 'NA' != "${downloaded_entries:=${3:-NA}}" ] &&
+    [ 'NA' != "${total_entries:-NA}" ] &&
+    [ "${downloaded_entries}" != "${total_entries}" ]
 then
     exit 1
 fi

--- a/tubesync/full_playlist.sh
+++ b/tubesync/full_playlist.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+echo "$1"
+echo "$2"
+exit 0
+
+if [ "$1" -ne "$2" ]
+then
+    exit 1
+fi
+
+exit 0

--- a/tubesync/full_playlist.sh
+++ b/tubesync/full_playlist.sh
@@ -2,9 +2,17 @@
 
 echo "$1"
 echo "$2"
-exit 0
+playlist_id="${1}"
+total_entries="${2}"
+set -x
 
-if [ 'NA' != "$2" ] && [ "$1" != "$2" ]
+time find / -path '*/infojson/playlist/*' \
+    -name "postprocessor_[${playlist_id}]_*_${total_entries}_temp.info.json"
+
+exit 0
+downloaded_entries=0
+
+if [ 'NA' != "${total_entries}" ] && [ "${downloaded_entries}" != "${total_entries}" ]
 then
     exit 1
 fi

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -161,13 +161,13 @@ def get_media_info(url, days=None):
     postprocessors.extend((dict(
         key='Exec',
         when='playlist',
-        exec_cmd="/usr/bin/env sh /app/full_playlist.sh '%(id)s' '%(playlist_count)d'",
+        exec_cmd="/usr/bin/env bash /app/full_playlist.sh '%(id)s' '%(playlist_count)d'",
     ),))
-    infojson_directory_path = Path(opts.get('cachedir', '/dev/shm')) / 'infojson',
+    infojson_directory_path = Path(opts.get('cachedir', '/dev/shm')) / 'infojson'
     playlist_infojson = 'postprocessor_[%(id)s]_%(n_entries)d_%(playlist_count)d_temp'
     outtmpl = dict(
         default='',
-        pl_infojson=f'{infojson_directory_path!s}/playlist/{playlist_infojson}.info.json',
+        pl_infojson=f'{infojson_directory_path}/playlist/{playlist_infojson}.%(ext)s',
     )
     for k in OUTTMPL_TYPES.keys():
         outtmpl.setdefault(k, '')

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -148,6 +148,7 @@ def get_media_info(url, days=None):
             f'yesterday-{days!s}days' if days else None
         )
     opts = get_yt_opts()
+    default_opts = yt_dlp.parse_options([]).options
     paths = opts.get('paths', dict())
     if 'temp' in paths:
         temp_dir_obj = TemporaryDirectory(prefix='.yt_dlp-', dir=paths['temp'])
@@ -156,6 +157,12 @@ def get_media_info(url, days=None):
         paths.update({
             'temp': str(temp_dir_path),
         })
+    postprocessors = opts.get('postprocessors', default_opts.get('postprocessors', list()))
+    postprocessors.extend(dict(
+        key='Exec',
+        when='playlist',
+        exec_cmd='/usr/bin/env sh /app/full_playlist.sh %(playlist_count)d %(n_entries)d',
+    ))
     opts.update({
         'ignoreerrors': False, # explicitly set this to catch exceptions
         'ignore_no_formats_error': False, # we must fail first to try again with this enabled
@@ -170,6 +177,7 @@ def get_media_info(url, days=None):
             'youtubetab': {'approximate_date': ['true']},
         },
         'paths': paths,
+        'postprocessors': postprocessors,
         'skip_unavailable_fragments': False,
         'sleep_interval_requests': 2 * settings.BACKGROUND_TASK_ASYNC_THREADS,
         'verbose': True if settings.DEBUG else False,

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -162,11 +162,11 @@ def get_media_info(url, /, *, days=None, info_json=None):
         })
     try:
         info_json_path = Path(info_json).resolve(strict=False)
-    except:
+    except (RuntimeError, TypeError):
         pass
     else:
-        opts['paths'].update({
-            'infojson': user_set('infojson', opts['paths'], str(info_json_path))
+        paths.update({
+            'infojson': user_set('infojson', paths, str(info_json_path))
         })
     default_postprocessors = user_set('postprocessors', default_opts.__dict__, list())
     postprocessors = user_set('postprocessors', opts, default_postprocessors)
@@ -179,6 +179,7 @@ def get_media_info(url, /, *, days=None, info_json=None):
     playlist_infojson = 'postprocessor_[%(id)s]_%(n_entries)d_%(playlist_count)d_temp'
     outtmpl = dict(
         default='',
+        infojson='%(id)s.%(ext)s' if paths['infojson'] else '',
         pl_infojson=f'{cache_directory_path}/infojson/playlist/{playlist_infojson}.%(ext)s',
     )
     for k in OUTTMPL_TYPES.keys():

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -163,11 +163,11 @@ def get_media_info(url, days=None):
         when='playlist',
         exec_cmd="/usr/bin/env bash /app/full_playlist.sh '%(id)s' '%(playlist_count)d'",
     ),))
-    infojson_directory_path = Path(opts.get('cachedir', '/dev/shm')) / 'infojson'
+    cache_directory_path = Path(opts.get('cachedir', '/dev/shm'))
     playlist_infojson = 'postprocessor_[%(id)s]_%(n_entries)d_%(playlist_count)d_temp'
     outtmpl = dict(
         default='',
-        pl_infojson=f'{infojson_directory_path}/playlist/{playlist_infojson}.%(ext)s',
+        pl_infojson=f'{cache_directory_path}/infojson/playlist/{playlist_infojson}.%(ext)s',
     )
     for k in OUTTMPL_TYPES.keys():
         outtmpl.setdefault(k, '')

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -179,7 +179,7 @@ def get_media_info(url, /, *, days=None, info_json=None):
     playlist_infojson = 'postprocessor_[%(id)s]_%(n_entries)d_%(playlist_count)d_temp'
     outtmpl = dict(
         default='',
-        infojson='%(id)s.%(ext)s' if user_set('infojson', paths, '') else '',
+        infojson='%(id)s.%(ext)s' if paths.get('infojson') else '',
         pl_infojson=f'{cache_directory_path}/infojson/playlist/{playlist_infojson}.%(ext)s',
     )
     for k in OUTTMPL_TYPES.keys():

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -158,11 +158,11 @@ def get_media_info(url, days=None):
             'temp': str(temp_dir_path),
         })
     postprocessors = opts.get('postprocessors', default_opts.get('postprocessors', list()))
-    postprocessors.extend(dict(
+    postprocessors.extend((dict(
         key='Exec',
         when='playlist',
         exec_cmd='/usr/bin/env sh /app/full_playlist.sh %(playlist_count)d %(n_entries)d',
-    ))
+    ),))
     opts.update({
         'ignoreerrors': False, # explicitly set this to catch exceptions
         'ignore_no_formats_error': False, # we must fail first to try again with this enabled

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -157,7 +157,7 @@ def get_media_info(url, days=None):
         paths.update({
             'temp': str(temp_dir_path),
         })
-    postprocessors = opts.get('postprocessors', default_opts.get('postprocessors', list()))
+    postprocessors = opts.get('postprocessors', default_opts.__dict__.get('postprocessors', list()))
     postprocessors.extend((dict(
         key='Exec',
         when='playlist',

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -179,7 +179,7 @@ def get_media_info(url, /, *, days=None, info_json=None):
     playlist_infojson = 'postprocessor_[%(id)s]_%(n_entries)d_%(playlist_count)d_temp'
     outtmpl = dict(
         default='',
-        infojson='%(id)s.%(ext)s' if paths['infojson'] else '',
+        infojson='%(id)s.%(ext)s' if user_set('infojson', paths, '') else '',
         pl_infojson=f'{cache_directory_path}/infojson/playlist/{playlist_infojson}.%(ext)s',
     )
     for k in OUTTMPL_TYPES.keys():


### PR DESCRIPTION
The idea for this is simple.
Check that we download all of the entries the playlist reported.

Rarely, a playlist result is too short for whatever reason. When this happens, and you are using "delete removed media" then a lot of media items will have been deleted.

Later, when the full playlist results are retrieved, all of those media items are being downloaded again.

We want to avoid this situation by skipping the index when the playlist is incomplete.

```
[tubesync/DEBUG] [info] Writing updated playlist metadata as JSON to: /config/cache/yt-dlp/infojson/playlist/postprocessor_[PLID]_100_876_temp.info.json                                  
[tubesync/DEBUG] [Exec] Executing command: /usr/bin/env bash /app/full_playlist.sh 'PLID' '876'
```

Failed playlists look like this:
```
  File "/usr/local/lib/python3.11/dist-packages/yt_dlp/postprocessor/exec.py", line 30, in run
    raise PostProcessingError(f'Command returned error code {return_code}')
yt_dlp.utils.PostProcessingError: Command returned error code 1
```