### PR TITLE
Fix video format sorting in case of missing keys

### DIFF
--- a/tubesync/sync/matching.py
+++ b/tubesync/sync/matching.py
@@ -95,6 +95,8 @@ def get_best_video_format(media):
             continue
         if not fmt['vcodec']:
             continue
+        if any(key[0] not in fmt for key in sort_keys):
+            continue
         if media.source.source_resolution.strip().upper() == fmt['format']:
             video_formats.append(fmt)
         elif media.source.source_resolution_height == fmt['height']:


### PR DESCRIPTION
Playlist indexing can fail with
```
  File "/app/sync/models.py", line 891, in get_format_str
    video_match, video_format = self.get_best_video_format()
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sync/models.py", line 871, in get_best_video_format
    return get_best_video_format(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sync/matching.py", line 120, in get_best_video_format
    video_formats = multi_key_sort(video_formats, sort_keys, True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sync/utils.py", line 191, in multi_key_sort
    result.sort(key=key_func(key), reverse=reverse)
TypeError: '<' not supported between instances of 'float' and 'NoneType'
```

Defend against this case by ensuring all sort keys are present in any considered formats