### PR TITLE
Add a post processor for after move

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -381,9 +381,29 @@ def download_media(
             'modifychapters+ffmpeg': codec_options,
         })
 
+    # Provide the user control of 'overwrites' in the post processors.
+    pp_opts.overwrites = opts.get(
+        'overwrites',
+        ytopts.get(
+            'overwrites',
+            default_opts.overwrites,
+        ),
+    )
+
     # Create the post processors list.
     # It already included user configured post processors as well.
     ytopts['postprocessors'] = list(yt_dlp.get_postprocessors(pp_opts))
+
+    if pp_opts.extractaudio:
+        ytopts['postprocessors'].append(dict(
+            key='Exec',
+            when='after_move',
+            exec_cmd=(
+                f'test -f {output_file} || '
+                'mv -f {} '
+                f'{output_file}'
+            ),
+        ))
 
     opts.update(ytopts)
 

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -395,6 +395,9 @@ def download_media(
     # It already included user configured post processors as well.
     ytopts['postprocessors'] = list(yt_dlp.get_postprocessors(pp_opts))
 
+    # The ExtractAudio post processor can change the extension.
+    # This post processor is to change the final filename back
+    # to what we are expecting it to be.
     final_path = Path(output_file)
     try:
         final_path = final_path.resolve(strict=True)


### PR DESCRIPTION
A possible improvement on this quick fix is to create a Python post processor that handles the rename and updates the information for later post processors.

This would run before the `MoveFiles` post processor does its work.

This pull request includes changes targeting [`overwrites`](https://github.com/yt-dlp/yt-dlp/blob/349f36606fa7fb658216334a73ac7825c13503c2/yt_dlp/postprocessor/movefilesafterdownload.py#L38) in `MoveFiles` also.

Fixes #983