### PR TITLE
Ignore `KeyError` when deleting keys

### DIFF
--- a/tubesync/sync/migrations/0032_metadata_transfer.py
+++ b/tubesync/sync/migrations/0032_metadata_transfer.py
@@ -16,8 +16,14 @@ def restore_metadata_column(apps, schema_editor):
     qs = Media.objects.filter(metadata__isnull=False)
     for media in qs_gen(qs):
         metadata = media.loaded_metadata
-        del metadata['migrated']
-        del metadata['_using_table']
+        try:
+            del metadata['migrated']
+        except KeyError:
+            pass
+        try:
+            del metadata['_using_table']
+        except KeyError:
+            pass
         media.metadata = media.metadata_dumps(arg_dict=metadata)
         media.save()
 

--- a/tubesync/sync/migrations/0032_metadata_transfer.py
+++ b/tubesync/sync/migrations/0032_metadata_transfer.py
@@ -16,14 +16,8 @@ def restore_metadata_column(apps, schema_editor):
     qs = Media.objects.filter(metadata__isnull=False)
     for media in qs_gen(qs):
         metadata = media.loaded_metadata
-        try:
-            del metadata['migrated']
-        except KeyError:
-            pass
-        try:
-            del metadata['_using_table']
-        except KeyError:
-            pass
+        for key in {'migrated', '_using_table'}:
+            metadata.pop(key, None)
         media.metadata = media.metadata_dumps(arg_dict=metadata)
         media.save()
 


### PR DESCRIPTION
It seems odd for Python to insist that a key I am trying to remove must exist already.

At least there is a way to do it without the checks or try blocks.