### PR TITLE
Copy updated thumbnail next to media

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -555,6 +555,16 @@ def download_media_thumbnail(media_id, url):
     )
     i = image_file = None
     log.info(f'Saved thumbnail for: {media} from: {url}')
+    # After media is downloaded, copy the updated thumbnail.
+    copy_thumbnail = (
+        media.downloaded and
+        media.source.copy_thumbnails and
+        media.thumb_file_exists
+    )
+    if copy_thumbnail:
+        log.info(f'Copying media thumbnail from: {media.thumb.path} '
+                 f'to: {media.thumbpath}')
+        copyfile(media.thumb.path, media.thumbpath)        
     return True
 
 


### PR DESCRIPTION
I've noticed that the newly replaced thumbnail isn't being used by my media server, because we never updated it.