### PR TITLE
Remux video for combined format download

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -336,12 +336,15 @@ def download_media(
         )
         # assignment is the quickest way to cover both 'get' cases
         pp_opts.exec_cmd['after_move'] = cmds
+    else:
+        pp_opts.remuxvideo = extension
 
     ytopts = {
         'format': media_format,
         'final_ext': extension,
         'merge_output_format': extension,
         'outtmpl': os.path.basename(output_file),
+        'remuxvideo': pp_opts.remuxvideo,
         'quiet': False if settings.DEBUG else True,
         'verbose': True if settings.DEBUG else False,
         'noprogress': None if settings.DEBUG else True,

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -336,7 +336,7 @@ def download_media(
         )
         # assignment is the quickest way to cover both 'get' cases
         pp_opts.exec_cmd['after_move'] = cmds
-    else:
+    elif '+' not in media_format:
         pp_opts.remuxvideo = extension
 
     ytopts = {


### PR DESCRIPTION
I recently noticed that the combined format was matching for one of my sources, but the tasks were failing because it downloaded with the `.mp4` extension.