### PR TITLE
Add `music.youtube.com` to the YouTube domains

### DIFF
--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -8,6 +8,7 @@ DOMAINS = dict({
     'youtube': frozenset({
         'youtube.com',
         'm.youtube.com',
+        'music.youtube.com',
         'www.youtube.com',
     }),
 })


### PR DESCRIPTION
Fixes #1024 