### PR TITLE
Log `OSError` when checking for existing media files

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -272,8 +272,15 @@ def media_post_save(sender, instance, created, **kwargs):
                 thumbnail_url,
                 verbose_name=verbose_name.format(instance.name),
             )
+    media_file_exists = False
+    try:
+        media_file_exists |= instance.media_file_exists
+        media_file_exists |= instance.filepath.exists()
+    except OSError as e:
+        log.exception(e)
+        pass
     # If the media has not yet been downloaded schedule it to be downloaded
-    if not (instance.media_file_exists or instance.filepath.exists() or existing_media_download_task):
+    if not (media_file_exists or existing_media_download_task):
         # The file was deleted after it was downloaded, skip this media.
         if instance.can_download and instance.downloaded:
             skip_changed = True != instance.skip


### PR DESCRIPTION
It is fine to schedule a download task when we might not need to because the task will either decide not to run itself or raise an exception outside of the post save signal handler.

https://github.com/meeb/tubesync/blob/73972c8b0c3f43e8490f310845e0a6d594ab8921/tubesync/sync/tasks.py#L605-L642


Fixes #1028