### PR TITLE
Create a media entry after deletion

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -313,7 +313,7 @@ def media_pre_delete(sender, instance, **kwargs):
             ),
         ),
     )
-    instance.save()
+    # TODO: instance.save()
     # Triggered before media is deleted, delete any unlocked scheduled tasks
     log.info(f'Deleting tasks for media: {instance.name}')
     delete_task_by_media('sync.tasks.download_media', (str(instance.pk),))

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from background_task.signals import task_failed
 from background_task.models import Task
 from common.logger import log
-from .models import Source, Media, MediaServer
+from .models import Source, Media, MediaServer, Metadata
 from .tasks import (delete_task_by_source, delete_task_by_media, index_source_task,
                     download_media_thumbnail, download_media_metadata,
                     map_task_to_instance, check_source_directory_exists,

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -396,7 +396,7 @@ def media_post_delete(sender, instance, **kwargs):
         key=instance.key,
         source=instance.source,
     )
-    if created:
+    if False and created:
         old_metadata = instance.loaded_metadata
         skipped_media.downloaded = False
         skipped_media.duration = instance.duration

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -313,7 +313,9 @@ def media_pre_delete(sender, instance, **kwargs):
             ),
         ),
     )
-    # TODO: instance.save()
+    # Do not create more tasks before deleting
+    instance.manual_skip = True
+    instance.save()
     # Triggered before media is deleted, delete any unlocked scheduled tasks
     log.info(f'Deleting tasks for media: {instance.name}')
     delete_task_by_media('sync.tasks.download_media', (str(instance.pk),))
@@ -396,7 +398,7 @@ def media_post_delete(sender, instance, **kwargs):
         key=instance.key,
         source=instance.source,
     )
-    if False and created:
+    if created:
         old_metadata = instance.loaded_metadata
         skipped_media.downloaded = False
         skipped_media.duration = instance.duration

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -933,6 +933,10 @@ def delete_all_media_for_source(source_id, source_name, source_directory):
         for media in qs_gen(mqs):
             log.info(f'Deleting media for source: {source_name} item: {media.name}')
             with atomic():
+                #media.downloaded = False
+                media.skip = True
+                media.manual_skip = True
+                media.save()
                 media.delete()
     # Remove the directory, if the user requested that
     directory_path = Path(source_directory)

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -469,8 +469,19 @@ class FrontEndTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
         # Confirm any tasks have been deleted
         q = {'task_name': 'sync.tasks.download_media_thumbnail'}
-        download_media_thumbnail_tasks = Task.objects.filter(**q)
-        self.assertFalse(download_media_thumbnail_tasks)
+        found_thumbnail_task1 = False
+        found_thumbnail_task2 = False
+        found_thumbnail_task3 = False
+        for task in Task.objects.filter(**q):
+            if test_media1_pk in task.task_params:
+                found_thumbnail_task1 = True
+            if test_media2_pk in task.task_params:
+                found_thumbnail_task2 = True
+            if test_media3_pk in task.task_params:
+                found_thumbnail_task3 = True
+        self.assertFalse(found_thumbnail_task1)
+        self.assertFalse(found_thumbnail_task2)
+        self.assertFalse(found_thumbnail_task3)
         q = {'task_name': 'sync.tasks.download_media'}
         download_media_tasks = Task.objects.filter(**q)
         self.assertFalse(download_media_tasks)

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -471,19 +471,6 @@ class FrontEndTestCase(TestCase):
         q = {'task_name': 'sync.tasks.download_media_thumbnail'}
         download_media_thumbnail_tasks = Task.objects.filter(**q)
         self.assertFalse(download_media_thumbnail_tasks)
-        found_thumbnail_task1 = False
-        found_thumbnail_task2 = False
-        found_thumbnail_task3 = False
-        for task in download_media_thumbnail_tasks:
-            if test_media1_pk in task.task_params:
-                found_thumbnail_task1 = True
-            if test_media2_pk in task.task_params:
-                found_thumbnail_task2 = True
-            if test_media3_pk in task.task_params:
-                found_thumbnail_task3 = True
-        self.assertFalse(found_thumbnail_task1)
-        self.assertFalse(found_thumbnail_task2)
-        self.assertFalse(found_thumbnail_task3)
         q = {'task_name': 'sync.tasks.download_media'}
         download_media_tasks = Task.objects.filter(**q)
         self.assertFalse(download_media_tasks)

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -469,10 +469,12 @@ class FrontEndTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
         # Confirm any tasks have been deleted
         q = {'task_name': 'sync.tasks.download_media_thumbnail'}
+        download_media_thumbnail_tasks = Task.objects.filter(**q)
+        self.assertFalse(download_media_thumbnail_tasks)
         found_thumbnail_task1 = False
         found_thumbnail_task2 = False
         found_thumbnail_task3 = False
-        for task in Task.objects.filter(**q):
+        for task in download_media_thumbnail_tasks:
             if test_media1_pk in task.task_params:
                 found_thumbnail_task1 = True
             if test_media2_pk in task.task_params:

--- a/tubesync/sync/tests.py
+++ b/tubesync/sync/tests.py
@@ -1847,5 +1847,6 @@ class TasksTestCase(TestCase):
         cleanup_old_media()
 
         self.assertEqual(src1.media_source.all().count(), 3)
-        self.assertEqual(src2.media_source.all().count(), 2)
+        self.assertEqual(src2.media_source.all().count(), 3)
         self.assertEqual(Media.objects.filter(pk=m22.pk).exists(), False)
+        self.assertEqual(Media.objects.filter(source=src2, key=m22.key, skip=True).exists(), True)


### PR DESCRIPTION
To optimize deletion of `Media` objects,
the `pre` and `post` signal handler functions are used together to save minimal information into a new instance that is marked as skipped.

Fixes #93