### PR TITLE
Schedule indexing tasks using `huey`

### DIFF
--- a/tubesync/sync/management/commands/reset-tasks.py
+++ b/tubesync/sync/management/commands/reset-tasks.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from background_task.models import Task
 from common.logger import log
 from sync.models import Source
-from sync.tasks import index_source_task, check_source_directory_exists
+from sync.tasks import check_source_directory_exists
 
 
 class Command(BaseCommand):
@@ -21,15 +21,6 @@ class Command(BaseCommand):
                 verbose_name = _('Check download directory exists for source "{}"')
                 check_source_directory_exists(
                     str(source.pk),
-                    verbose_name=verbose_name.format(source.name),
-                )
-                # Recreate the initial indexing task
-                log.info(f'Resetting tasks for source: {source}')
-                verbose_name = _('Index media from source "{}"')
-                index_source_task(
-                    str(source.pk),
-                    repeat=source.index_schedule,
-                    schedule=source.task_run_at_dt,
                     verbose_name=verbose_name.format(source.name),
                 )
                 # This also chains down to call each Media objects .save() as well

--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -95,7 +95,7 @@ def source_pre_save(sender, instance, **kwargs):
         verbose_name = _('Index media from source "{}"')
         index_source_task(
             str(instance.pk),
-            repeat=instance.index_schedule,
+            repeat=0,
             schedule=instance.task_run_at_dt,
             verbose_name=verbose_name.format(instance.name),
         )
@@ -118,7 +118,7 @@ def source_post_save(sender, instance, created, **kwargs):
             verbose_name = _('Index media from source "{}"')
             index_source_task(
                 str(instance.pk),
-                repeat=instance.index_schedule,
+                repeat=0,
                 schedule=600,
                 verbose_name=verbose_name.format(instance.name),
             )

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -251,7 +251,6 @@ def schedule_indexing():
             schedule=600,
             verbose_name=vn_fmt.format(source.name),
         )
-    pass
 
 
 def schedule_media_servers_update():

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -226,6 +226,7 @@ def save_model(instance):
     huey_crontab(minute=59, strict=True,),
     priority=100,
     expires=30*60,
+    queue=Val(TaskQueue.DB),
 )
 def schedule_indexing():
     now = timezone.now()

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -245,6 +245,7 @@ def schedule_indexing():
         )
         if skip_source:
             continue
+        log.info(f'Scheduling an indexing task for source "{source.name}": {source.pk}')
         vn_fmt = _('Index media from source "{}"')
         index_source_task(
             str(source.pk),

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -235,7 +235,7 @@ def schedule_indexing():
         index_schedule__gt=Val(IndexSchedule.NEVER),
     )
     for source in qs_gen(qs):
-        previous_run = now - timezone.timedelta(
+        previous_run = next_hour - timezone.timedelta(
             seconds=source.index_schedule
         )
         skip_source = (

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -28,7 +28,7 @@ from background_task import background
 from background_task.exceptions import InvalidTaskError
 from background_task.models import Task, CompletedTask
 from django_huey import db_periodic_task, db_task, task as huey_task # noqa
-from huey import CancelExecution
+from huey import CancelExecution, crontab as huey_crontab
 from common.huey import dynamic_retry
 from common.logger import log
 from common.errors import ( BgTaskWorkerError, DownloadFailedException,
@@ -36,7 +36,7 @@ from common.errors import ( BgTaskWorkerError, DownloadFailedException,
                             NoThumbnailException, )
 from common.utils import (  django_queryset_generator as qs_gen,
                             remove_enclosed, seconds_to_timestr, )
-from .choices import Val, TaskQueue
+from .choices import Val, IndexSchedule, TaskQueue
 from .models import Source, Media, MediaServer, Metadata
 from .utils import get_remote_image, resize_image_to_height, filter_response
 from .youtube import YouTubeError
@@ -220,6 +220,38 @@ def save_model(instance):
     # "database is locked" errors
     arg = getattr(settings, 'SQLITE_DELAY_FLOAT', 1.5)
     time.sleep(random.expovariate(arg))
+
+
+@db_periodic_task(
+    huey_crontab(minute=59, strict=True,),
+    priority=100,
+    expires=30*60,
+)
+def schedule_indexing():
+    now = timezone.now()
+    next_hour = now + timezone.timedelta(hours=1, minutes=1)
+    qs = Source.objects.filter(
+        index_schedule__gt=Val(IndexSchedule.NEVER),
+    )
+    for source in qs:
+        previous_run = now - timezone.timedelta(
+            seconds=source.index_schedule
+        )
+        skip_source = (
+            not source.is_active or
+            source.target_schedule >= next_hour or
+            source.last_crawl >= previous_run
+        )
+        if skip_source:
+            continue
+        vn_fmt = _('Index media from source "{}"')
+        index_source_task(
+            str(source.pk),
+            repeat=0,
+            schedule=600,
+            verbose_name=vn_fmt.format(source.name),
+        )
+    pass
 
 
 def schedule_media_servers_update():

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -233,7 +233,7 @@ def schedule_indexing():
     qs = Source.objects.filter(
         index_schedule__gt=Val(IndexSchedule.NEVER),
     )
-    for source in qs:
+    for source in qs_gen(qs):
         previous_run = now - timezone.timedelta(
             seconds=source.index_schedule
         )

--- a/tubesync/sync/views.py
+++ b/tubesync/sync/views.py
@@ -999,14 +999,6 @@ class ResetTasks(FormView):
                 str(source.pk),
                 verbose_name=verbose_name.format(source.name),
             )
-            # Recreate the initial indexing task
-            verbose_name = _('Index media from source "{}"')
-            index_source_task(
-                str(source.pk),
-                repeat=source.index_schedule,
-                schedule=source.task_run_at_dt,
-                verbose_name=verbose_name.format(source.name)
-            )
             # This also chains down to call each Media objects .save() as well
             source.save()
         return super().form_valid(form)


### PR DESCRIPTION
The idea here is to not use `repeat` at all.

Instead, the source is evaluated every hour to see if it should be indexed.

This should also let us stop deleting indexing tasks.

```
[2025-06-16 10:59:13,749] INFO:huey.consumer.Scheduler:208:Enqueueing periodic task sync.tasks.schedule_indexing: 88d70b27-2461-4b7c-9be1-bb7bc7c77e97 exp=1800 p=100.
[2025-06-16 10:59:32,823] INFO:huey:209:Executing sync.tasks.schedule_indexing: 88d70b27-2461-4b7c-9be1-bb7bc7c77e97 exp=1800 (2025-06-16 11:29:13.750442) p=100
[2025-06-16 10:59:32,945] INFO:huey:209:sync.tasks.schedule_indexing: 88d70b27-2461-4b7c-9be1-bb7bc7c77e97 exp=1800 (2025-06-16 11:29:13.750442) p=100 executed in 0.121s
```

```
[2025-06-16 12:59:26,448] INFO:huey.consumer.Scheduler:6350:Enqueueing periodic task sync.tasks.schedule_indexing: 6d2f7fcb-1fa1-42d4-aa6e-544bb6108de2 exp=1800 p=100.
[2025-06-16 12:59:40,863] INFO:huey:6351:Executing sync.tasks.schedule_indexing: 6d2f7fcb-1fa1-42d4-aa6e-544bb6108de2 exp=1800 (2025-06-16 13:29:26.451387) p=100
2025-06-16 12:59:40,921 [tubesync/INFO] Scheduling an indexing task for source "@NAME": 2b0d4ae5-85f0-43a9-bfa8-cce3dd83dfa5
[2025-06-16 12:59:41,106] INFO:huey:6351:sync.tasks.schedule_indexing: 6d2f7fcb-1fa1-42d4-aa6e-544bb6108de2 exp=1800 (2025-06-16 13:29:26.451387) p=100 executed in 0.240s
2025-06-16 13:09:47,169 [tubesync/INFO] Deleting completed tasks older than 7 days (run_at before 2025-06-09 13:09:47.169020+00:00)
2025-06-16 13:09:47,198 [tubesync/DEBUG] get_media_info: used date range: 2025-06-08 to 9999-12-31 for URL: https://www.youtube.com/channel/CHANNEL_ID/videos
```

```
Index media from source "@NAME"
Queue: "network"
Task locked for: 00:02:18
 Task locked at 2025-06-16 13:09:47
 Task ended at 2025-06-16 13:12:04

Delaying checking all media for database tasks
Queue: "filesystem"
Task locked for: 00:30:13
 Task locked at 2025-06-16 13:11:34
 Task ended at 2025-06-16 13:41:46

Waiting for database tasks to complete
Queue: "network"
Task locked for: 00:29:42
 Task locked at 2025-06-16 13:12:05
 Task ended at 2025-06-16 13:41:47

Checking all media for "@NAME"
Queue: "filesystem"
Task locked for: 00:07:14
 Task locked at 2025-06-16 13:47:32
 Task ended at 2025-06-16 13:54:46
```

Reminder: the thumbnail downloads are in the `filesystem` queue. That's why there is a gap of a few minutes before the checking task was locked.
