### PR TITLE
Create a path around `download_media_thumbnail`

### DIFF
--- a/tubesync/sync/models/media__tasks.py
+++ b/tubesync/sync/models/media__tasks.py
@@ -103,7 +103,7 @@ def copy_thumbnail(self):
     if not self.source.copy_thumbnails:
         return
     if not self.thumb_file_exists:
-        from sync.tasks import delete_task_by_media, download_media_thumbnail
+        from sync.tasks import delete_task_by_media, download_media_image
         args = ( str(self.pk), self.thumbnail, )
         if not args[1]:
             return

--- a/tubesync/sync/models/media__tasks.py
+++ b/tubesync/sync/models/media__tasks.py
@@ -108,7 +108,7 @@ def copy_thumbnail(self):
         if not args[1]:
             return
         delete_task_by_media('sync.tasks.download_media_thumbnail', args)
-        if download_media_thumbnail.now(*args):
+        if download_media_image.call_local(*args):
             self.refresh_from_db()
     if not self.thumb_file_exists:
         return

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -497,17 +497,15 @@ def index_source_task(source_id):
             log.info(f'Indexed new media: {source} / {media}')
             log.info(f'Scheduling tasks to download thumbnail for: {media.key}')
             thumbnail_fmt = 'https://i.ytimg.com/vi/{}/{}default.jpg'
-            vn_fmt = _('Downloading {} thumbnail for: "{}": {}')
-            for num, prefix in enumerate(('hq', 'sd', 'maxres',)):
+            for num, prefix in enumerate(reversed(('hq', 'sd', 'maxres',))):
                 thumbnail_url = thumbnail_fmt.format(
                     media.key,
                     prefix,
                 )
-                download_media_thumbnail(
-                    str(media.pk),
-                    thumbnail_url,
-                    schedule=dict(run_at=10+(300*num)),
-                    verbose_name=vn_fmt.format(prefix, media.key, media.name),
+                download_media_image.schedule(
+                    (str(media.pk), thumbnail_url,),
+                    priority=10+(5*num),
+                    delay=65-(30*num),
                 )
             log.info(f'Scheduling task to download metadata for: {media.url}')
             verbose_name = _('Downloading metadata for: "{}": {}')


### PR DESCRIPTION
I'm not touching this further until after the tasks history is sorted out and the tasks page is updated.

However, I still want to benefit from the new queues, so here we are.