### PR TITLE
Provide a string where it is expected

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -992,7 +992,7 @@ def refresh_formats(media_id):
                 retry=retry,
             )
             # combine the strings
-            exc.args = (' '.join(exc.args),)
+            exc.args = (' '.join(map(str, exc.args)),)
             # store instance details
             exc.instance = dict(
                 key=media.key,


### PR DESCRIPTION
```
[tubesync/DEBUG] (<class 'django.utils.functional.lazy.<locals>.__proxy__'>, <class 'str'>, <class 'str'>)
```