### PR TITLE
Add `allow_unicode=True` to `slugify`

### DIFF
--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -726,8 +726,11 @@ class Media(models.Model):
             '_': '-',
             '&': 'and', '+': 'and',
         })
-        slugified = slugify(self.title.translate(transtab), allow_unicode=True)
-        decoded = slugified.encode(errors=''ignore').decode()
+        slugified = slugify(
+            self.title.translate(transtab),
+            allow_unicode=True,
+        )
+        decoded = slugified.encode(errors='ignore').decode()
         return decoded[:80]
 
     @property

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -723,7 +723,6 @@ class Media(models.Model):
     @property
     def slugtitle(self):
         transtab = str.maketrans({
-            '_': '-',
             '&': 'and', '+': 'and',
         })
         slugified = slugify(

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -723,7 +723,7 @@ class Media(models.Model):
     @property
     def slugtitle(self):
         replaced = self.title.replace('_', '-').replace('&', 'and').replace('+', 'and')
-        return slugify(replaced)[:80]
+        return slugify(replaced, allow_unicode=True)[:80]
 
     @property
     def thumbnail(self):

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -722,9 +722,11 @@ class Media(models.Model):
 
     @property
     def slugtitle(self):
-        no_underscores = self.title.replace('_', '-')
-        to_and = no_underscores.replace('&', 'and').replace('+', 'and')
-        slugified = slugify(to_and, allow_unicode=True)
+        transtab = str.maketrans({
+            '_': '-',
+            '&': 'and', '+': 'and',
+        })
+        slugified = slugify(self.title.translate(transtab), allow_unicode=True)
         decoded = slugified.encode(errors=''ignore').decode()
         return decoded[:80]
 

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -722,8 +722,11 @@ class Media(models.Model):
 
     @property
     def slugtitle(self):
-        replaced = self.title.replace('_', '-').replace('&', 'and').replace('+', 'and')
-        return slugify(replaced, allow_unicode=True)[:80]
+        no_underscores = self.title.replace('_', '-')
+        to_and = no_underscores.replace('&', 'and').replace('+', 'and')
+        slugified = slugify(to_and, allow_unicode=True)
+        decoded = slugified.encode(errors=''ignore').decode()
+        return decoded[:80]
 
     @property
     def thumbnail(self):

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -730,7 +730,11 @@ class Media(models.Model):
             self.title.translate(transtab),
             allow_unicode=True,
         )
-        decoded = slugified.encode(errors='ignore').decode()
+        encoding = os.sys.getfilesystemencoding()
+        decoded = slugified.encode(
+            encoding=encoding,
+            errors='ignore',
+        ).decode(encoding=encoding)
         return decoded[:80]
 
     @property


### PR DESCRIPTION
I haven't given this change great consideration.
If there is a reason not to allow Unicode, then please let me know.

@meeb Why are underscores disallowed?


Fixes #527 