### PR TITLE
Turn off `ignoreerrors`

### DIFF
--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -199,7 +199,7 @@ YOUTUBE_DL_TEMPDIR = None
 YOUTUBE_DEFAULTS = {
     'color': 'never',       # Do not use colours in output
     'age_limit': 99,        # 'Age in years' to spoof
-    'ignoreerrors': True,   # Skip on errors (such as unavailable videos in playlists)
+    'ignoreerrors': False,  # When true, yt-dlp does not raise descriptive exceptions
     'cachedir': False,      # Disable on-disk caching
     'addmetadata': True,    # Embed metadata during postprocessing where available
     'geo_verification_proxy': getenv('geo_verification_proxy').strip() or None,


### PR DESCRIPTION
We only download one video at a time, so skipping over a failed download isn't something that we want.

The current default is: `only_download`

```py
>>> import yt_dlp
>>> default_opts = yt_dlp.parse_options([]).options
>>> default_opts.ignoreerrors
'only_download'
```