### PR TITLE
Create youtube-add-subscriptions.py

### DIFF
--- a/tubesync/sync/management/commands/youtube-add-subscriptions.py
+++ b/tubesync/sync/management/commands/youtube-add-subscriptions.py
@@ -1,7 +1,6 @@
 import json
 import urllib
 from django.core.management.base import BaseCommand, CommandError # noqa
-from sync.youtube import get_media_info
 from common.json import JSONEncoder
 
 

--- a/tubesync/sync/management/commands/youtube-add-subscriptions.py
+++ b/tubesync/sync/management/commands/youtube-add-subscriptions.py
@@ -27,7 +27,13 @@ class Command(BaseCommand):
             self.stderr.write(e)
         subscriptions = info.get('subscriptions', [])
         keys = ('channelId', 'title',)
-        sources = [ {k:v for k,v in s.get('snippet', {}).items() if k in keys and v not in existing_sources} for s in subscriptions ]
+        sources = [
+            {
+                k:v for k,v in s.get('snippet', {}).items() \
+                if k in keys
+            } for s in subscriptions \
+            if s.get('snippet', {}).get(keys[0]) not in existing_sources
+        ]
         d = json.dumps(sources, indent=4, sort_keys=True, cls=JSONEncoder)
         self.stdout.write(d)
         self.stderr.write('Done')

--- a/tubesync/sync/management/commands/youtube-add-subscriptions.py
+++ b/tubesync/sync/management/commands/youtube-add-subscriptions.py
@@ -2,12 +2,13 @@ import json
 import urllib
 from django.core.management.base import BaseCommand, CommandError # noqa
 from common.json import JSONEncoder
+from sync.choices import Val, YouTube_SourceType # noqa
 from sync.models import Source
 
 
 class Command(BaseCommand):
 
-    help = 'Displays subscription information in JSON to the console'
+    help = 'Adds sources for any new subscription information'
 
     def add_arguments(self, parser):
         parser.add_argument('url', type=str)
@@ -36,5 +37,19 @@ class Command(BaseCommand):
         ]
         d = json.dumps(sources, indent=4, sort_keys=True, cls=JSONEncoder)
         self.stdout.write(d)
+        source_objs = [
+            Source(key=s[keys[0]], name=s[keys[1]]) for s in sources
+        ]
+        for source in source_objs:
+            source.source_type = YouTube_SourceType.CHANNEL_ID
+            source.copy_channel_images = True
+            source.directory = source.slugname
+            source.embed_thumbnail = True
+            source.enable_sponsorblock = False
+            source.prefer_60fps = False
+            source.write_json = True
+            source.write_subtitles = True
+            source.save()
+            self.stderr.write(f'Added a new source: {source.name}')
         self.stderr.write('Done')
 

--- a/tubesync/sync/management/commands/youtube-add-subscriptions.py
+++ b/tubesync/sync/management/commands/youtube-add-subscriptions.py
@@ -1,0 +1,28 @@
+import json
+import urllib
+from django.core.management.base import BaseCommand, CommandError # noqa
+from sync.youtube import get_media_info
+from common.json import JSONEncoder
+
+
+class Command(BaseCommand):
+
+    help = 'Displays subscription information in JSON to the console'
+
+    def add_arguments(self, parser):
+        parser.add_argument('url', type=str)
+
+    def handle(self, *args, **options):
+        url = options['url']
+        self.stderr.write(f'Showing information for URL: {url}')
+        info = dict()
+        try:
+            request = urllib.request.Request(url)
+            with urllib.request.urlopen(request) as response:
+                info = json.loads(response.read().decode())
+        except urllib.error.HTTPError as e:
+            self.stderr.write(e)
+        d = json.dumps(info, indent=4, sort_keys=True, cls=JSONEncoder)
+        self.stdout.write(d)
+        self.stderr.write('Done')
+

--- a/tubesync/sync/management/commands/youtube-add-subscriptions.py
+++ b/tubesync/sync/management/commands/youtube-add-subscriptions.py
@@ -27,18 +27,18 @@ class Command(BaseCommand):
         except urllib.error.HTTPError as e:
             self.stderr.write(e)
         subscriptions = info.get('subscriptions', [])
-        keys = ('channelId', 'title',)
+        keys = ('channelId', 'resourceId', 'title',)
         sources = [
             {
                 k:v for k,v in s.get('snippet', {}).items() \
                 if k in keys
             } for s in subscriptions \
-            if s.get('snippet', {}).get(keys[0]) not in existing_sources
+            if s.get('snippet', {}).get(keys[1], {}).get(keys[0]) not in existing_sources
         ]
         d = json.dumps(sources, indent=4, sort_keys=True, cls=JSONEncoder)
         self.stdout.write(d)
         source_objs = [
-            Source(key=s[keys[0]], name=s[keys[1]]) for s in sources
+            Source(key=s[keys[1]][keys[0]], name=s[keys[2]]) for s in sources
         ]
         for source in source_objs:
             source.source_type = YouTube_SourceType.CHANNEL_ID


### PR DESCRIPTION
This command uses a URL generated by: https://ytsubs.app
(Thanks to @derekantrican for that site.)

It can be run through crontab on the docker host or manually to add sources that don't already exist from the subscriptions associated with a YouTube user account.

Fixes #245