### PR TITLE
Do not schedule a duplicate `save_all_media_for_source` task

### DIFF
--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -611,18 +611,8 @@ def index_source(source_id):
     videos = video = None
     db_batch_data.clear()
     db_batch_media.clear()
-    # Let the checking task run
+    # Let the checking task created by saving `last_crawl` run
     indexing_lock.clear()
-    # Trigger any signals that we skipped with batched updates
-    TaskHistory.schedule(
-        save_all_media_for_source,
-        str(source.pk),
-        delay=60,
-        vn_fmt = _('Checking all media for "{}"'),
-        vn_args=(
-            source.name,
-        ),
-    )
     return True
 
 


### PR DESCRIPTION
When `Source.last_crawl` is updated and saved the `source_post_save` receiver function creates a `save_all_media_for_source` task.

By holding a lock that task needs before that save happen, we can delay it until after indexing has completed.

This replaces the previous method of deleting the task, then creating a new task after the indexing was completed.

Requires #1181 