### PR TITLE
Download other formats on failure

### DIFF
--- a/tubesync/common/errors.py
+++ b/tubesync/common/errors.py
@@ -47,3 +47,16 @@ class DatabaseConnectionError(Exception):
 class BgTaskWorkerError(Exception):
     # Raised when the worker process is not in a normal working state.
     pass
+
+
+class HueyConsumerError(Exception):
+    # Raised when the consumer process is not in a normal working state.
+    pass
+
+
+class FormatUnavailableError(Exception):
+    def __init__(self, *args, exc=None, format=None, **kwargs):
+        self.exc = exc
+        self.format = format
+        super().__init__(*args, **kwargs)
+

--- a/tubesync/sync/models/media.py
+++ b/tubesync/sync/models/media.py
@@ -41,7 +41,7 @@ from ._migrations import (
 from ._private import _srctype_dict, _nfo_element
 from .media__tasks import (
     copy_thumbnail, download_checklist, download_finished,
-    refresh_formats, wait_for_premiere, write_nfo_file,
+    failed_format, refresh_formats, wait_for_premiere, write_nfo_file,
 )
 from .source import Source
 
@@ -1179,6 +1179,7 @@ class Media(models.Model):
 Media.copy_thumbnail = copy_thumbnail
 Media.download_checklist = download_checklist
 Media.download_finished = download_finished
+Media.failed_format = failed_format
 Media.refresh_formats = refresh_formats
 Media.wait_for_premiere = wait_for_premiere
 Media.write_nfo_file = write_nfo_file

--- a/tubesync/sync/models/media__tasks.py
+++ b/tubesync/sync/models/media__tasks.py
@@ -124,6 +124,21 @@ def download_finished(self, format_str, container, downloaded_filepath=None):
             self.downloaded_format = Val(SourceResolution.AUDIO)
 
 
+def failed_format(self, format_str, /, *, cause=None, exc=None):
+    if not self.has_metadata:
+        return
+    t = format_str.partition('+')
+    data = self.loaded_metadata
+    field = self.get_metadata_field('formats')
+    formats = data.get(field, list())
+    new_formats = [
+        f
+        for f in formats
+        if f.get('format_id') not in (t[0],)
+    ]
+    self.save_to_metadata(field, new_formats)
+
+
 def refresh_formats(self):
     if not self.has_metadata:
         return (None, False, 'missing metadata') # save, retry, msg

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -432,7 +432,11 @@ def download_media(
         try:
             return y.download([url])
         except yt_dlp.utils.DownloadError as e:
-            if ': Requested format is not available.' in str(e):
+            remove_unavailable_format = (
+                settings.YOUTUBE_DL_SKIP_UNAVAILABLE_FORMAT and
+                ': Requested format is not available.' in str(e)
+            )
+            if remove_unavailable_format:
                 raise FormatUnavailableError(url, exc=e.__cause__, format=opts.get('format')) from e
             raise YouTubeError(f'Failed to download for "{url}": {e}') from e
     return False

--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -6,6 +6,7 @@
 
 import os
 
+from common.errors import FormatUnavailableError
 from common.logger import log
 from common.utils import mkdir_p
 from copy import deepcopy
@@ -431,5 +432,7 @@ def download_media(
         try:
             return y.download([url])
         except yt_dlp.utils.DownloadError as e:
+            if ': Requested format is not available.' in str(e):
+                raise FormatUnavailableError(url, exc=e.__cause__, format=opts.get('format')) from e
             raise YouTubeError(f'Failed to download for "{url}": {e}') from e
     return False

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -193,6 +193,7 @@ SOURCE_DOWNLOAD_DIRECTORY_PREFIX = True
 
 YOUTUBE_DL_CACHEDIR = None
 YOUTUBE_DL_TEMPDIR = None
+YOUTUBE_DL_SKIP_UNAVAILABLE_FORMAT = False
 YOUTUBE_DEFAULTS = {
     'color': 'never',       # Do not use colours in output
     'age_limit': 99,        # 'Age in years' to spoof


### PR DESCRIPTION
The `YOUTUBE_DL_SKIP_UNAVAILABLE_FORMAT` setting must be `True` to test/use the new behavior.