### PR TITLE
Improve `/app/restart_services.sh`

### DIFF
--- a/tubesync/restart_services.sh
+++ b/tubesync/restart_services.sh
@@ -26,7 +26,7 @@ only_longruns() {
 
 if [ 0 -eq $# ]
 then
-    set -- $(/command/s6-rc -e -a list)
+    set -- $(only_longruns $(/command/s6-rc -e -a list))
 fi
 
 for arg in "$@"


### PR DESCRIPTION
- ~`s6-rc-db` has a useful list of bundles~
- `sc-rc` list accepts bundles/services the same way
- ~`s6-rc-db` can expand multiple bundles~
- `s6-rc-db` reports the type of a service
- Add `is_a_longrun` & `only_longruns` functions
- By default, restart all `longrun` services that are already `up`
- Do not try to restart essential services
- Remove find/grep work-arounds
- Remove the check for a bundle
- Remove the list of longruns and seevices