### PR TITLE
feat: add AssetType/AssetCodec choices and Codec model

### DIFF
--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -257,6 +257,19 @@ class YouTube_VideoCodec(models.TextChoices):
     AVC1 = 'AVC1', _('AVC1 (H.264)')
 
 
+class AssetType(models.TextChoices):
+    THUMBNAIL = 'thumbnail', _('Thumbnail')
+    AUDIO = 'audio', _('Audio')
+    VIDEO = 'video', _('Video')
+
+
+class AssetCodec(models.TextChoices):
+    JPEG = 'jpeg', _('JPEG')
+    OPUS = 'opus', _('Opus')
+    VP9 = 'vp9', _('VP9')
+    AV1 = 'av1', _('AV1')
+
+
 SourceResolutionInteger = SourceResolution._integer_mapping()
 youtube_long_source_types = YouTube_SourceType._long_type_mapping()
 youtube_validation_urls = YouTube_SourceType._validation_urls()

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -261,15 +261,20 @@ class AssetType(models.TextChoices):
     THUMBNAIL = 'thumbnail', _('Thumbnail')
     AUDIO = 'audio', _('Audio')
     VIDEO = 'video', _('Video')
+    SUBTITLE = 'subtitle', _('Subtitle')
 
 
 class AssetCodec(models.TextChoices):
     JPEG = 'jpeg', _('JPEG')
+    PNG = 'png', _('PNG')
     OPUS = 'OPUS', _('Opus')
     MP4A = 'MP4A', _('MP4A')
     AV1 = 'AV1', _('AV1')
     VP9 = 'VP9', _('VP9')
     AVC1 = 'AVC1', _('AVC1 (H.264)')
+    VTT = 'vtt', _('WebVTT')
+    SRT = 'srt', _('SubRip')
+    ASS = 'ass', _('Advanced SubStation Alpha')
 
 
 SourceResolutionInteger = SourceResolution._integer_mapping()

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -274,6 +274,7 @@ class AssetCodec(models.TextChoices):
     VP9 = 'VP9', _('VP9')
     AVC1 = 'AVC1', _('AVC1 (H.264)')
     VTT = 'vtt', _('WebVTT')
+    TTML = 'ttml', _('TTML')
     SRT = 'srt', _('SubRip')
     ASS = 'ass', _('Advanced SubStation Alpha')
 

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -267,7 +267,8 @@ class AssetCodec(models.TextChoices):
     JPEG = 'jpeg', _('JPEG')
     OPUS = 'OPUS', _('Opus')
     MP4A = 'MP4A', _('MP4A')
-    VP9 = 'vp9', _('VP9')
+    AV1 = 'AV1', _('AV1')
+    VP9 = 'VP9', _('VP9')
     AVC1 = 'AVC1', _('AVC1 (H.264)')
 
 

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -268,7 +268,7 @@ class AssetCodec(models.TextChoices):
     OPUS = 'OPUS', _('Opus')
     MP4A = 'MP4A', _('MP4A')
     VP9 = 'vp9', _('VP9')
-    AV1 = 'av1', _('AV1')
+    AVC1 = 'AVC1', _('AVC1 (H.264)')
 
 
 SourceResolutionInteger = SourceResolution._integer_mapping()

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -265,7 +265,8 @@ class AssetType(models.TextChoices):
 
 class AssetCodec(models.TextChoices):
     JPEG = 'jpeg', _('JPEG')
-    OPUS = 'opus', _('Opus')
+    OPUS = 'OPUS', _('Opus')
+    MP4A = 'MP4A', _('MP4A')
     VP9 = 'vp9', _('VP9')
     AV1 = 'av1', _('AV1')
 

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -269,7 +269,7 @@ class AssetCodec(models.TextChoices):
     WEBP = 'webp', _('WEBP')
     PNG = 'png', _('PNG')
     OPUS = 'OPUS', _('Opus')
-    MP4A = 'MP4A', _('MP4A')
+    MP4A = 'M4A', _('MP4A')
     AV1 = 'AV1', _('AV1')
     VP9 = 'VP9', _('VP9')
     AVC1 = 'AVC1', _('AVC1 (H.264)')

--- a/tubesync/sync/choices.py
+++ b/tubesync/sync/choices.py
@@ -265,7 +265,8 @@ class AssetType(models.TextChoices):
 
 
 class AssetCodec(models.TextChoices):
-    JPEG = 'jpeg', _('JPEG')
+    JPEG = 'jpg', _('JPEG')
+    WEBP = 'webp', _('WEBP')
     PNG = 'png', _('PNG')
     OPUS = 'OPUS', _('Opus')
     MP4A = 'MP4A', _('MP4A')

--- a/tubesync/sync/models/__init__.py
+++ b/tubesync/sync/models/__init__.py
@@ -10,6 +10,7 @@ from ._migrations import (
 # The order starts with independent classes
 # then the classes that depend on them follow.
 
+from .codec import Codec
 from .media_server import MediaServer
 
 from .source import Source
@@ -19,7 +20,6 @@ from .metadata_format import MetadataFormat
 
 __all__ = [
     'get_media_file_path', 'get_media_thumb_path',
-    'media_file_storage', 'MediaServer', 'Source',
+    'media_file_storage', 'Codec', 'MediaServer', 'Source',
     'Media', 'Metadata', 'MetadataFormat',
 ]
-

--- a/tubesync/sync/models/codec.py
+++ b/tubesync/sync/models/codec.py
@@ -1,0 +1,42 @@
+import uuid
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from ..choices import AssetType, AssetCodec
+
+
+class Codec(models.Model):
+    '''
+        Codec is a supported codec for a given asset type.
+    '''
+
+    uuid = models.UUIDField(
+        _('uuid'),
+        primary_key=True,
+        editable=False,
+        default=uuid.uuid4,
+        help_text=_('UUID of the codec'),
+    )
+    asset_type = models.CharField(
+        _('asset type'),
+        max_length=16,
+        db_index=True,
+        choices=AssetType.choices,
+        help_text=_('The type of asset this codec is used for'),
+    )
+    codec = models.CharField(
+        _('codec'),
+        max_length=16,
+        db_index=True,
+        choices=AssetCodec.choices,
+        help_text=_('The codec name'),
+    )
+
+    def __str__(self):
+        return f'{self.asset_type} / {self.codec}'
+
+    class Meta:
+        verbose_name = _('Codec')
+        verbose_name_plural = _('Codecs')
+        unique_together = (
+            ('asset_type', 'codec'),
+        )


### PR DESCRIPTION
Closes #1420
Closes #1421

## Changes

### `tubesync/sync/choices.py`
- Added `AssetType` choices: `thumbnail`, `audio`, `video`
- Added `AssetCodec` choices: `jpeg`, `opus`, `vp9`, `av1`

### `tubesync/sync/models/codec.py`
- Added new `Codec` model with `asset_type` and `codec` fields
- Uses `AssetType` and `AssetCodec` choices
- UUID primary key
- Unique together constraint on `(asset_type, codec)`

### `tubesync/sync/models/__init__.py`
- Exported `Codec` from the models package