### PR TITLE
fix: pin `huey` to version 2.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pycodestyle = "*"
 
 [packages]
 django = "~=6.0.0"
+huey = "~=2.6"
 django-huey = "*"
 django-sass-processor = {extras = ["management-command"], version = "*"}
 pillow = "*"


### PR DESCRIPTION
See:
- #1454 