### PR TITLE
feat: add Subtitle model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ on:
     branches:
       - 'main'
       - 'test-*'
+      - 'issue/1419/*'
     types:
       - opened
       - reopened

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ Pipfile.lock
 # Ignore Jetbrains IDE files
 .idea/
 
+# Kiro IDE files (specs, configs, steering — not for the repo)
+.kiro/
+
 # Task queue DBs
 /tubesync/tasks/*.db
 /tubesync/tasks/*.db-shm

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 autopep8 = "*"
+hypothesis = "*"
 pycodestyle = "*"
 
 [packages]

--- a/tubesync/sync/admin.py
+++ b/tubesync/sync/admin.py
@@ -68,8 +68,8 @@ class MediaServerAdmin(admin.ModelAdmin):
 @admin.register(Subtitle)
 class SubtitleAdmin(admin.ModelAdmin):
 
-    ordering = ('language', 'extension')
-    list_display = ('id', 'language', 'extension', 'original_language', 'machine_generated', 'codec')
+    ordering = ('extension', 'language')
+    list_display = ('id', 'extension', 'original_language', 'language', 'machine_generated', 'codec')
     list_filter = ('machine_generated',)
-    search_fields = ('language', 'extension', 'original_language')
+    search_fields = ('extension', 'language', 'original_language')
 

--- a/tubesync/sync/admin.py
+++ b/tubesync/sync/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from .models import (
-    Codec, # noqa: F401
+    Codec,
     Source,
     Media,
     Metadata,
@@ -45,6 +45,16 @@ class MetadataFormatAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'site', 'number', 'metadata')
     readonly_fields = ('uuid', 'metadata', 'site', 'key', 'number')
     search_fields = ('uuid', 'metadata__uuid', 'metadata__media__uuid', 'key')
+
+
+@admin.register(Codec)
+class CodecAdmin(admin.ModelAdmin):
+
+    ordering = ('asset_type', 'codec')
+    list_display = ('uuid', 'asset_type', 'codec', 'description')
+    list_filter = ('asset_type',)
+    readonly_fields = ('uuid',)
+    search_fields = ('codec', 'description')
 
 
 @admin.register(MediaServer)

--- a/tubesync/sync/admin.py
+++ b/tubesync/sync/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from .models import (
-    Codec,
+    Codec, # noqa: F401
     Source,
     Media,
     Metadata,

--- a/tubesync/sync/admin.py
+++ b/tubesync/sync/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 from .models import (
+    Codec,
     Source,
     Media,
     Metadata,
     MetadataFormat,
-    MediaServer
+    MediaServer,
+    Subtitle,
 )
 
 
@@ -51,3 +53,13 @@ class MediaServerAdmin(admin.ModelAdmin):
     ordering = ('host', 'port')
     list_display = ('pk', 'server_type', 'host', 'port', 'use_https', 'verify_https')
     search_fields = ('host',)
+
+
+@admin.register(Subtitle)
+class SubtitleAdmin(admin.ModelAdmin):
+
+    ordering = ('language', 'extension')
+    list_display = ('id', 'language', 'extension', 'original_language', 'machine_generated', 'codec')
+    list_filter = ('machine_generated',)
+    search_fields = ('language', 'extension', 'original_language')
+

--- a/tubesync/sync/migrations/0040_subtitle.py
+++ b/tubesync/sync/migrations/0040_subtitle.py
@@ -1,0 +1,63 @@
+# Generated migration for the Subtitle model (issue #1453)
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sync', '0039_codec_data'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Subtitle',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True, primary_key=True, serialize=False, verbose_name='ID',
+                    ),
+                ),
+                ('extension', models.CharField(
+                    help_text='The file extension of the subtitle (e.g. vtt, srt)',
+                    max_length=8,
+                    verbose_name='extension',
+                    ),
+                ),
+                ('language', models.CharField(
+                    help_text='BCP-47 language tag of the subtitle track (e.g. en-US)',
+                    max_length=16,
+                    verbose_name='language',
+                    ),
+                ),
+                ('original_language', models.CharField(
+                    blank=False,
+                    default=None,
+                    help_text='BCP-47 language tag of the source language, or NULL if unknown',
+                    max_length=16,
+                    null=True,
+                    verbose_name='original language',
+                    ),
+                ),
+                ('machine_generated', models.BooleanField(
+                    default=False,
+                    help_text='Whether the subtitle was automatically generated',
+                    verbose_name='machine generated',
+                    ),
+                ),
+                ('codec', models.ForeignKey(
+                    help_text='The codec used for this subtitle track',
+                    null=True,
+                    on_delete=models.deletion.SET_NULL,
+                    related_name='subtitles',
+                    to='sync.codec',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'Subtitle',
+                'verbose_name_plural': 'Subtitles',
+                'unique_together': {('language', 'extension')},
+            },
+        ),
+    ]
+

--- a/tubesync/sync/models/__init__.py
+++ b/tubesync/sync/models/__init__.py
@@ -17,9 +17,11 @@ from .source import Source
 from .media import Media
 from .metadata import Metadata
 from .metadata_format import MetadataFormat
+from .subtitle import Subtitle
 
 __all__ = [
     'get_media_file_path', 'get_media_thumb_path',
     'media_file_storage', 'Codec', 'MediaServer', 'Source',
-    'Media', 'Metadata', 'MetadataFormat',
+    'Media', 'Metadata', 'MetadataFormat', 'Subtitle',
 ]
+

--- a/tubesync/sync/models/codec.py
+++ b/tubesync/sync/models/codec.py
@@ -44,3 +44,4 @@ class Codec(models.Model):
         unique_together = (
             ('asset_type', 'codec'),
         )
+

--- a/tubesync/sync/models/subtitle.py
+++ b/tubesync/sync/models/subtitle.py
@@ -1,0 +1,55 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from .codec import Codec
+
+
+class Subtitle(models.Model):
+    '''
+        Subtitle is a subtitle track available for a media item.
+    '''
+
+    extension = models.CharField(
+        _('extension'),
+        max_length=8,
+        blank=False,
+        null=False,
+        help_text=_('The file extension of the subtitle (e.g. vtt, srt)'),
+    )
+    language = models.CharField(
+        _('language'),
+        max_length=16,
+        blank=False,
+        null=False,
+        help_text=_('BCP-47 language tag of the subtitle track (e.g. en-US)'),
+    )
+    original_language = models.CharField(
+        _('original language'),
+        max_length=16,
+        blank=False,
+        null=True,
+        default=None,
+        help_text=_('BCP-47 language tag of the source language, or NULL if unknown'),
+    )
+    machine_generated = models.BooleanField(
+        _('machine generated'),
+        default=False,
+        help_text=_('Whether the subtitle was automatically generated'),
+    )
+    codec = models.ForeignKey(
+        Codec,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name='subtitles',
+        help_text=_('The codec used for this subtitle track'),
+    )
+
+    class Meta:
+        verbose_name = _('Subtitle')
+        verbose_name_plural = _('Subtitles')
+        unique_together = (
+            ('language', 'extension'),
+        )
+
+    def __str__(self):
+        return f'{self.language} ({self.extension})'
+

--- a/tubesync/sync/models/subtitle.py
+++ b/tubesync/sync/models/subtitle.py
@@ -51,5 +51,5 @@ class Subtitle(models.Model):
         )
 
     def __str__(self):
-        return f'{self.language} ({self.extension})'
+        return f'{self.extension} / {self.language}'
 

--- a/tubesync/sync/tests/test_subtitle.py
+++ b/tubesync/sync/tests/test_subtitle.py
@@ -1,0 +1,87 @@
+import uuid
+from django.db import IntegrityError
+from django.test import TestCase
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.django import TestCase as HypothesisTestCase
+from sync.models import Codec, Subtitle
+
+
+class SubtitleModelTestCase(TestCase):
+    '''Example-based tests for the Subtitle model.'''
+
+    def _make_codec(self):
+        codec, _ = Codec.objects.get_or_create(
+            asset_type='subtitle',
+            codec='vtt',
+            defaults={
+                'uuid': uuid.uuid4(),
+                'description': 'Web Video Text Tracks',
+            },
+        )
+        return codec
+
+    def test_create_with_valid_fields(self):
+        # Req 8.1: create with valid fields and codec=None persists without error
+        subtitle = Subtitle.objects.create(
+            language='en-US',
+            extension='vtt',
+            original_language=None,
+            machine_generated=False,
+            codec=None,
+        )
+        self.assertIsNotNone(subtitle.pk)
+
+    def test_original_language_none_stores_null(self):
+        # Req 8.2 / 1.3: original_language=None stores NULL, not empty string
+        Subtitle.objects.create(
+            language='en-US',
+            extension='vtt',
+            original_language=None,
+        )
+        subtitle = Subtitle.objects.get(language='en-US', extension='vtt')
+        self.assertIsNone(subtitle.original_language)
+
+    def test_duplicate_language_extension_raises_integrity_error(self):
+        # Req 8.3 / 2.1 / 2.2: unique_together on (language, extension)
+        Subtitle.objects.create(language='en-US', extension='vtt')
+        with self.assertRaises(IntegrityError):
+            Subtitle.objects.create(language='en-US', extension='vtt')
+
+    def test_str_representation(self):
+        # Req 8.4 / 3.1: __str__ returns '{language} ({extension})'
+        subtitle = Subtitle(language='en-US', extension='vtt')
+        self.assertEqual(str(subtitle), 'en-US (vtt)')
+
+    def test_machine_generated_defaults_to_false(self):
+        # Req 1.4: machine_generated defaults to False
+        subtitle = Subtitle.objects.create(language='fr-FR', extension='srt')
+        self.assertFalse(subtitle.machine_generated)
+
+    def test_codec_set_null_on_codec_deletion(self):
+        # Req 1.5: SET_NULL — deleting Codec sets subtitle.codec to None
+        codec = self._make_codec()
+        subtitle = Subtitle.objects.create(
+            language='es-US',
+            extension='vtt',
+            codec=codec,
+        )
+        codec.delete()
+        subtitle.refresh_from_db()
+        self.assertIsNone(subtitle.codec)
+
+
+class SubtitleStrPropertyTest(HypothesisTestCase):
+    '''Property-based test: __str__ format is universal (Property 1).'''
+
+    @given(
+        language=st.text(min_size=1, max_size=16).filter(lambda s: s == s.strip()),
+        extension=st.text(min_size=1, max_size=8).filter(lambda s: s == s.strip()),
+    )
+    @settings(max_examples=100)
+    def test_str_format_property(self, language, extension):
+        # Property 1: for any non-empty language and extension,
+        # str(Subtitle) == f'{language} ({extension})'
+        subtitle = Subtitle(language=language, extension=extension)
+        self.assertEqual(str(subtitle), f'{language} ({extension})')
+

--- a/tubesync/sync/tests/test_subtitle.py
+++ b/tubesync/sync/tests/test_subtitle.py
@@ -49,9 +49,9 @@ class SubtitleModelTestCase(TestCase):
             Subtitle.objects.create(language='en-US', extension='vtt')
 
     def test_str_representation(self):
-        # Req 8.4 / 3.1: __str__ returns '{language} ({extension})'
+        # Req 8.4 / 3.1: __str__ returns '{extension} / {language}'
         subtitle = Subtitle(language='en-US', extension='vtt')
-        self.assertEqual(str(subtitle), 'en-US (vtt)')
+        self.assertEqual(str(subtitle), 'vtt / en-US')
 
     def test_machine_generated_defaults_to_false(self):
         # Req 1.4: machine_generated defaults to False
@@ -81,7 +81,7 @@ class SubtitleStrPropertyTest(HypothesisTestCase):
     @settings(max_examples=100)
     def test_str_format_property(self, language, extension):
         # Property 1: for any non-empty language and extension,
-        # str(Subtitle) == f'{language} ({extension})'
+        # str(Subtitle) == f'{extension} / {language}'
         subtitle = Subtitle(language=language, extension=extension)
-        self.assertEqual(str(subtitle), f'{language} ({extension})')
+        self.assertEqual(str(subtitle), f'{extension} / {language}')
 


### PR DESCRIPTION
- Add Codec model and AssetType choices (from issue/1419/design-generic-models)
- Add migrations 0038_codec, 0039_codec_data, 0040_subtitle
- Register SubtitleAdmin in admin.py
- Add tests: 6 example-based + 1 Hypothesis property test

closes #1453