### PR TITLE
chore(ci): reset dive to reasonable settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,8 +194,8 @@ jobs:
             'ghcr.io/wagoodman/dive' \
             'ghcr.io/${{ needs.info.outputs.lowercase-github-repository_owner }}/${{ env.IMAGE_NAME }}:dive' \
             --ci \
-            --highestUserWastedPercent '0.08' \
-            --highestWastedBytes '60M'
+            --highestUserWastedPercent '0.05' \
+            --highestWastedBytes '25M'
 
   docker-image:
     if: ${{ !cancelled() && 'success' == needs.info.result && 'success' == needs.containerise.result }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     PIP_NO_COMPILE=1 \
     PIP_ROOT_USER_ACTION='ignore'
 
-#COPY --from=tubesync-etc /etc/debconf.conf /etc/debconf.conf
+COPY --from=tubesync-etc /etc/debconf.conf /etc/debconf.conf
 
 RUN --mount=type=cache,id=apt-lib-cache-${TARGETARCH},sharing=private,target=/var/lib/apt \
     --mount=type=cache,id=apt-cache-cache,sharing=private,target=/var/cache/apt \


### PR DESCRIPTION
To work around an outdated and broken Debian image / packages combination I had relaxed the limits and disabled our `/etc/debconf.conf` changes.

This commit reverses those temporary changes.