### PR TITLE
chore: add /web-logs/index.html link to the dashboard

### DIFF
--- a/tubesync/sync/templates/sync/dashboard.html
+++ b/tubesync/sync/templates/sync/dashboard.html
@@ -64,6 +64,17 @@
       </a>
     </div>
   </div>
+  <div class="col s12 m6 xl3">
+    <div class="card dashcard">
+      <a href="/web-logs/index.html">
+        <div class="card-content">
+          <h3 class="truncate"><i class="fas fa-fw fa-file-alt"></i></h3>
+          <div class="desc truncate">web logs</div>
+          <div class="truncate">View application log files</div>
+        </div>
+      </a>
+    </div>
+  </div>
   <div class="col s12 l6">
     <div class="card dashcard">
       <div class="card-content">


### PR DESCRIPTION
Closes #1489

Adds a dashcard to the dashboard linking to `/web-logs/index.html`, consistent with the existing card style (same `dashcard` class, same structure as the sources/media/tasks/disk usage cards).