### PR TITLE
fix(sync): strip subtitles and automatic_captions from metadata to prevent database bloat

### DIFF
--- a/tubesync/sync/tests/test_response_filtering.py
+++ b/tubesync/sync/tests/test_response_filtering.py
@@ -80,12 +80,9 @@ class ResponseFilteringTestCase(TestCase):
         filtered_url_keys = url_keys
         self.assertEqual(3, len(filtered_url_keys), msg=str(filtered_url_keys))
 
-        url_keys = []
-        for lang_code, captions in filtered['automatic_captions'].items():
-            for caption in captions:
-                for key in caption.keys():
-                    if 'url' in key:
-                        url_keys.append((lang_code, caption['ext'], caption[key],))
-        self.assertEqual(0, len(url_keys), msg=str(url_keys))
+        self.assertNotIn('automatic_captions', filtered.keys())
+        self.assertNotIn('subtitles', filtered.keys())
+        self.assertIn('automatic_captions', unfiltered.keys())
+        self.assertIn('subtitles', unfiltered.keys())
 
 

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -230,7 +230,12 @@ def filter_response(arg_dict, copy_arg=False):
     # end of formats cleanup }}}
 
     # beginning of subtitles cleanup {{{
-    # drop urls that expire
+    # Completely delete subtitles and automatic_captions to prevent database bloat
+    for key in ('subtitles', 'automatic_captions',):
+        if key in response_dict.keys():
+            del response_dict[key]
+
+    # drop urls that expire for requested_subtitles
     def drop_subtitles_url(**kwargs):
         url = kwargs['url']
         return (
@@ -242,7 +247,7 @@ def filter_response(arg_dict, copy_arg=False):
             )
         )
 
-    for key in ('subtitles', 'requested_subtitles', 'automatic_captions',):
+    for key in ('requested_subtitles',):
         if key in response_dict.keys():
             lang_codes = response_dict[key]
             if isinstance(lang_codes, dict):


### PR DESCRIPTION
Strip `subtitles` and `automatic_captions` from the cached video metadata to prevent excessive database bloat. 

### Rationale
These fields added excessive database bloat, and removing them in my case achieved significant size reduction:

| Metric | Before | After | Change |
| :--- | :--- | :--- | :--- |
| **Average Metadata Object Size** | 66.60 KB | 2.18 KB | -64.42 KB (96.7% reduction) |
| **Logical Database Size** | 8.50 GB | 1.20 GB | -7.30 GB (85.8% reduction) |

### Impact on Media Download
This change should have no effect on media download. TubeSync reads the subtitle preferences directly from the `Source` configuration database model (i.e., what you set in the TubeSync UI) and not from the video's cached `Metadata` model.
