### PR TITLE
feat(huey): flexible backoff algorithms

### DIFF
--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -10,6 +10,7 @@ from huey import (
     signals, utils,
 )
 from huey.api import Task, TaskLock
+from huey.exceptions import TaskLockedException
 from huey.storage import SqliteStorage as huey_SqliteStorage
 from pathlib import Path
 from .timestamp import datetime_to_timestamp, timestamp_to_datetime
@@ -21,8 +22,7 @@ def _set_acquired(self, value=True):
         return self.clear()
     try:
         self.__enter__()
-    # ruff: ignore[BLE001]
-    except Exception:
+    except TaskLockedException:
         return False
     else:
         return True

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -613,9 +613,13 @@ class AttemptsTask(Task):
 
         self.backoff_class = backoff_class or self.backoff_class
         if self.backoff_class:
-            self.retry_backoff = self.retry_backoff or 1
             # Register directly onto the algorithm base class
             self._backoff_key = self.backoff_base_class.register(self.backoff_class)
+
+        algo_key = getattr(self, '_backoff_key', None)
+        retry_backoff = kwargs.get('retry_backoff', None)
+        if retry_backoff is None and not self.default_retry_backoff and algo_key:
+            self.retry_backoff = 1
 
     @property
     def retry_delay(self) -> int:

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import subprocess
 import time

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -246,6 +246,7 @@ def h_q_reset_tasks(q, /, *, maint_func=None):
     if maint_func and callable(maint_func):
         try:
             maint_result = maint_func(q, status='started')
+        # ruff: ignore[BLE001]
         except Exception as exc:
             maint_result = maint_func(q, exception=exc, status='exception')
         finally:

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -125,6 +125,7 @@ class Huey(huey_Huey):
             try:
                 from common.models import TaskHistory
                 th = TaskHistory.objects.get(task_id=previous_id)
+            # ruff: ignore[S110]
             except:
                 pass
             else:
@@ -438,6 +439,7 @@ def historical_task(signal_name, task_obj, exception_obj=None, /, *, huey=None):
             try:
                 from django.core.exceptions import ValidationError
                 from sync.models import Media, Source
+            # ruff: ignore[S110]
             except:
                 pass
             else:

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -589,12 +589,6 @@ class BackoffAlgorithm(object):
         """
         algorithm_key = issubclass(algorithm, cls) and getattr(algorithm, 'key', cls.key)
         if algorithm_key:
-            if algorithm_key in cls._registry:
-                warnings.warn(
-                    f'{cls.__name__} collision detected! Overwriting key: {algorithm_key}',
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
             cls._registry.update({ algorithm_key: algorithm })
             return algorithm_key
 
@@ -617,26 +611,28 @@ class AttemptsTask(Task):
 
     def __init__(self, *args, backoff_class=None, **kwargs):
         super().__init__(*args, **kwargs)
-        if backoff_class:
+
+        self.backoff_class = backoff_class or self.backoff_class
+        if self.backoff_class:
+            self.retry_backoff = self.retry_backoff or 1
             # Register directly onto the algorithm base class
-            self._backoff_key = self.backoff_base_class.register(backoff_class)
+            self._backoff_key = self.backoff_base_class.register(self.backoff_class)
 
     @property
     def retry_delay(self) -> int:
         attempt = getattr(self, '_custom_attempt_counter', 1)
+        initial_delay = getattr(self, '_initial_configured_delay', 0)
+
         algo_key = getattr(self, '_backoff_key', None)
         algo_class = self.backoff_base_class.lookup(algo_key)
-        if algo_class and issubclass(algo_class, self.backoff_base_class):
+
+        if self.retry_backoff is None or 0 == self.retry_backoff:
+            return initial_delay
+        elif algo_class and issubclass(algo_class, self.backoff_base_class):
             return algo_class.calculate(attempt)
 
         # Fallback Mode: Exponential math using Task-resolved defaults
-        initial_delay = getattr(self, '_initial_configured_delay', 0)
-        backoff_factor = getattr(self, 'retry_backoff', 1)
-
-        if backoff_factor is None or 0 == backoff_factor:
-            return initial_delay
-
-        return initial_delay * (backoff_factor ** max(0, attempt - 1))
+        return initial_delay * (self.retry_backoff ** max(0, attempt - 1))
 
     @retry_delay.setter
     def retry_delay(self, value):

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -21,6 +21,7 @@ def _set_acquired(self, value=True):
         return self.clear()
     try:
         self.__enter__()
+    # ruff: ignore[BLE001]
     except Exception:
         return False
     else:
@@ -80,9 +81,7 @@ class Huey(huey_Huey):
 
     # do not use __len__ (pending_count) for bool
     def __bool__(self):
-        if not (self._registry._registry or self._registry._periodic_tasks):
-            return False
-        return True
+        return (self._registry._registry or self._registry._periodic_tasks)
 
     def _emit(self, signal, task, *args, **kwargs):
         kwargs['huey'] = self
@@ -515,7 +514,7 @@ def register_huey_signals():
                 # so the created datetime is the fail-safe case.
                 seconds = now_time - history.get(signals.SIGNAL_EXECUTING, now_time)
                 age = datetime.timedelta(
-                    seconds=(seconds if seconds > 0 else 0),
+                    seconds=max(0, seconds),
                 )
             else:
                 age = now_dt - history['created']
@@ -526,6 +525,7 @@ def register_huey_signals():
 
 
 class BackoffAlgorithm:
+    # ruff: ignore[RUF012]
     _registry = {}
     key = None
 

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -624,13 +624,14 @@ class AttemptsTask(Task):
     @property
     def retry_delay(self) -> int:
         attempt = getattr(self, '_custom_attempt_counter', 1)
-        initial_delay = getattr(self, '_initial_configured_delay', 0)
+        initial_delay = getattr(self, '_initial_retry_delay', 0)
 
         algo_key = getattr(self, '_backoff_key', None)
         algo_class = self.backoff_base_class.lookup(algo_key)
 
         if self.retry_backoff is None or 0 == self.retry_backoff:
-            return initial_delay
+            current_delay = getattr(self, '_retry_delay', initial_delay)
+            return current_delay
         elif algo_class and issubclass(algo_class, self.backoff_base_class):
             return algo_class.calculate(attempt)
 
@@ -642,8 +643,9 @@ class AttemptsTask(Task):
         current_state = getattr(self, '_custom_attempt_counter', None)
 
         if current_state is None:
-            self._initial_configured_delay = value
+            self._initial_retry_delay = value
             self._custom_attempt_counter = 1
         else:
             self._custom_attempt_counter = 1 + current_state
+        self._retry_delay = value
 

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -504,6 +504,7 @@ def register_huey_signals():
         # clean up old history and results from storage
         now_time = time.monotonic()
         now_dt = datetime.datetime.now(datetime.timezone.utc)
+        # ruff: ignore[SIM118]
         for key in q.all_results().keys():
             if not key.startswith(storage_key_prefix):
                 continue

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -2,12 +2,13 @@ import datetime
 import subprocess
 import time
 import uuid
+import warnings
 from functools import partial, wraps
 from huey import (
     CancelExecution, Huey as huey_Huey,
     signals, utils,
 )
-from huey.api import TaskLock
+from huey.api import Task, TaskLock
 from huey.storage import SqliteStorage as huey_SqliteStorage
 from pathlib import Path
 from .timestamp import datetime_to_timestamp, timestamp_to_datetime
@@ -565,4 +566,83 @@ def register_huey_signals():
                 result_key = key[len(storage_key_prefix) :]
                 q.get(peek=False, key=result_key)
                 q.get(peek=False, key=key)
+
+
+class BackoffAlgorithm(object):
+    _registry = {}
+    key = None
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        raise NotImplementedError()
+
+    @classmethod
+    def lookup(cls, key: str) -> BackoffAlgorithm | None:
+        return cls._registry.get(key, None)
+
+    @classmethod
+    def register(cls, algorithm: BackoffAlgorithm) -> str | None:
+        """
+        Merges a BackoffAlgorithm subclass into the base class registry.
+        """
+        algorithm_key = issubclass(algorithm, cls) and getattr(algorithm, 'key', cls.key)
+        if algorithm_key:
+            if algorithm_key in cls._registry:
+                warnings.warn(
+                    f'{cls.__name__} collision detected! Overwriting key: {algorithm_key}',
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            cls._registry.update({ algorithm_key: algorithm })
+            return algorithm_key
+
+
+class DjangoBackgroundTasksBackoff(BackoffAlgorithm):
+    key = 'Django-Background-Tasks'
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        # The exact formula used by django-background-tasks
+        return 5 + (attempt ** 4)
+
+
+class AttemptsTask(Task):
+    """
+    A Task base class that relies entirely on Task for defaults.
+    Resolves algorithms using string keys mapped onto the BackoffAlgorithm base class.
+    """
+    backoff_base_class = BackoffAlgorithm
+
+    def __init__(self, *args, backoff_class=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if backoff_class:
+            # Register directly onto the algorithm base class
+            self._backoff_key = self.backoff_base_class.register(backoff_class)
+
+    @property
+    def retry_delay(self) -> int:
+        attempt = getattr(self, '_custom_attempt_counter', 1)
+        algo_key = getattr(self, '_backoff_key', None)
+        algo_class = self.backoff_base_class.lookup(algo_key)
+        if algo_class and issubclass(algo_class, self.backoff_base_class):
+            return algo_class.calculate(attempt)
+
+        # Fallback Mode: Exponential math using Task-resolved defaults
+        initial_delay = getattr(self, '_initial_configured_delay', 0)
+        backoff_factor = getattr(self, 'retry_backoff', 1)
+
+        if backoff_factor is None or 0 == backoff_factor:
+            return initial_delay
+
+        return initial_delay * (backoff_factor ** max(0, attempt - 1))
+
+    @retry_delay.setter
+    def retry_delay(self, value):
+        current_state = getattr(self, '_custom_attempt_counter', None)
+
+        if current_state is None:
+            self._initial_configured_delay = value
+            self._custom_attempt_counter = 1
+        else:
+            self._custom_attempt_counter = 1 + current_state
 

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -4,7 +4,7 @@ import datetime
 import subprocess
 import time
 import uuid
-from functools import partial, wraps
+from functools import partial
 from huey import (
     CancelExecution, Huey as huey_Huey,
     signals, utils,
@@ -305,50 +305,6 @@ def sqlite_tasks(key, /, prefix=None, thread=None, workers=None, *, tasks_dir=No
             verbose=False,
         ),
     )
-
-# Decorators
-
-def dynamic_retry(task_func=None, /, *args, **kwargs):
-    if task_func is None:
-        from django_huey import task as huey_task
-        task_func = huey_task
-    backoff_func = kwargs.pop('backoff_func', None)
-    def default_backoff(attempt, /):
-        return (5+(attempt**4))
-    if backoff_func is None or not callable(backoff_func):
-        backoff_func = default_backoff
-    def deco(fn):
-        @wraps(fn)
-        def inner(*a, **kwa):
-            backoff = backoff_func
-            # the scoping becomes complicated when reusing functions
-            try:
-                _task = kwa.pop('task')
-            except KeyError:
-                pass
-            else:
-                task = _task
-            try:
-                return fn(*a, **kwa)
-            except Exception as exc:
-                try:
-                    task is not None
-                except NameError:
-                    raise exc
-                for attempt in range(1, 240):
-                    if backoff(attempt) > task.retry_delay:
-                        task.retry_delay = backoff(attempt)
-                        break
-                    # insanity, but handle it anyway
-                    if 239 == attempt:
-                        task.retry_delay = backoff(attempt)
-                raise exc
-        kwargs.update(dict(
-            context=True,
-            retry_delay=backoff_func(1),
-        ))
-        return task_func(*args, **kwargs)(inner)
-    return deco
 
 # Signal handlers shared between queues
 

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -4,7 +4,6 @@ import datetime
 import subprocess
 import time
 import uuid
-import warnings
 from functools import partial, wraps
 from huey import (
     CancelExecution, Huey as huey_Huey,
@@ -589,12 +588,6 @@ class BackoffAlgorithm:
         """
         algorithm_key = issubclass(algorithm, cls) and getattr(algorithm, 'key', cls.key)
         if algorithm_key:
-            if algorithm_key in cls._registry:
-                warnings.warn(
-                    f'{cls.__name__} collision detected! Overwriting key: {algorithm_key}',
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
             cls._registry.update({ algorithm_key: algorithm })
             return algorithm_key
 
@@ -617,26 +610,28 @@ class AttemptsTask(Task):
 
     def __init__(self, *args, backoff_class=None, **kwargs):
         super().__init__(*args, **kwargs)
-        if backoff_class:
+
+        self.backoff_class = backoff_class or self.backoff_class
+        if self.backoff_class:
+            self.retry_backoff = self.retry_backoff or 1
             # Register directly onto the algorithm base class
-            self._backoff_key = self.backoff_base_class.register(backoff_class)
+            self._backoff_key = self.backoff_base_class.register(self.backoff_class)
 
     @property
     def retry_delay(self) -> int:
         attempt = getattr(self, '_custom_attempt_counter', 1)
+        initial_delay = getattr(self, '_initial_configured_delay', 0)
+
         algo_key = getattr(self, '_backoff_key', None)
         algo_class = self.backoff_base_class.lookup(algo_key)
-        if algo_class and issubclass(algo_class, self.backoff_base_class):
+
+        if self.retry_backoff is None or 0 == self.retry_backoff:
+            return initial_delay
+        elif algo_class and issubclass(algo_class, self.backoff_base_class):
             return algo_class.calculate(attempt)
 
         # Fallback Mode: Exponential math using Task-resolved defaults
-        initial_delay = getattr(self, '_initial_configured_delay', 0)
-        backoff_factor = getattr(self, 'retry_backoff', 1)
-
-        if backoff_factor is None or 0 == backoff_factor:
-            return initial_delay
-
-        return initial_delay * (backoff_factor ** max(0, attempt - 1))
+        return initial_delay * (self.retry_backoff ** max(0, attempt - 1))
 
     @retry_delay.setter
     def retry_delay(self, value):

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import datetime
 import subprocess
 import time
 import uuid
+import warnings
 from functools import partial, wraps
 from huey import (
     CancelExecution, Huey as huey_Huey,
     signals, utils,
 )
-from huey.api import TaskLock
+from huey.api import Task, TaskLock
 from huey.storage import SqliteStorage as huey_SqliteStorage
 from pathlib import Path
 from .timestamp import datetime_to_timestamp, timestamp_to_datetime
@@ -565,4 +568,83 @@ def register_huey_signals():
                 result_key = key[len(storage_key_prefix) :]
                 q.get(peek=False, key=result_key)
                 q.get(peek=False, key=key)
+
+
+class BackoffAlgorithm:
+    _registry = {}
+    key = None
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        raise NotImplementedError()
+
+    @classmethod
+    def lookup(cls, key: str) -> BackoffAlgorithm | None:
+        return cls._registry.get(key, None)
+
+    @classmethod
+    def register(cls, algorithm: BackoffAlgorithm) -> str | None:
+        """
+        Merges a BackoffAlgorithm subclass into the base class registry.
+        """
+        algorithm_key = issubclass(algorithm, cls) and getattr(algorithm, 'key', cls.key)
+        if algorithm_key:
+            if algorithm_key in cls._registry:
+                warnings.warn(
+                    f'{cls.__name__} collision detected! Overwriting key: {algorithm_key}',
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            cls._registry.update({ algorithm_key: algorithm })
+            return algorithm_key
+
+
+class DjangoBackgroundTasksBackoff(BackoffAlgorithm):
+    key = 'Django-Background-Tasks'
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        # The exact formula used by django-background-tasks
+        return 5 + (attempt ** 4)
+
+
+class AttemptsTask(Task):
+    """
+    A Task base class that relies entirely on Task for defaults.
+    Resolves algorithms using string keys mapped onto the BackoffAlgorithm base class.
+    """
+    backoff_base_class = BackoffAlgorithm
+
+    def __init__(self, *args, backoff_class=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if backoff_class:
+            # Register directly onto the algorithm base class
+            self._backoff_key = self.backoff_base_class.register(backoff_class)
+
+    @property
+    def retry_delay(self) -> int:
+        attempt = getattr(self, '_custom_attempt_counter', 1)
+        algo_key = getattr(self, '_backoff_key', None)
+        algo_class = self.backoff_base_class.lookup(algo_key)
+        if algo_class and issubclass(algo_class, self.backoff_base_class):
+            return algo_class.calculate(attempt)
+
+        # Fallback Mode: Exponential math using Task-resolved defaults
+        initial_delay = getattr(self, '_initial_configured_delay', 0)
+        backoff_factor = getattr(self, 'retry_backoff', 1)
+
+        if backoff_factor is None or 0 == backoff_factor:
+            return initial_delay
+
+        return initial_delay * (backoff_factor ** max(0, attempt - 1))
+
+    @retry_delay.setter
+    def retry_delay(self, value):
+        current_state = getattr(self, '_custom_attempt_counter', None)
+
+        if current_state is None:
+            self._initial_configured_delay = value
+            self._custom_attempt_counter = 1
+        else:
+            self._custom_attempt_counter = 1 + current_state
 

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -4,7 +4,6 @@ import datetime
 import subprocess
 import time
 import uuid
-import warnings
 from functools import partial, wraps
 from huey import (
     CancelExecution, Huey as huey_Huey,

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -412,6 +412,8 @@ def historical_task(signal_name, task_obj, exception_obj=None, /, *, huey=None):
         huey.get(key=storage_key)
     else:
         huey.put(key=storage_key, data=history)
+    # created never used
+    # ruff: ignore[RUF059]
     th, created = TaskHistory.objects.get_or_create(
         task_id=str(task_obj.id),
         name=f"{task_obj.__module__}.{task_obj.name}",

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -719,7 +719,7 @@ def check_source_directory_exists(source_id):
         source.make_directory()
 
 
-@dynamic_retry(db_task, delay=10, priority=90, retries=15, queue=Val(TaskQueue.LIMIT))
+@db_task(delay=10, priority=90, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.LIMIT))
 def download_source_images(source_id):
     '''
         Downloads an image and save it as a local thumbnail attached to a

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -26,7 +26,7 @@ from huey import crontab as huey_crontab, signals as huey_signals
 from huey.exceptions import TaskLockedException
 from common.huey import (
     AttemptsTask, BackoffAlgorithm, CancelExecution, DjangoBackgroundTasksBackoff,
-    dynamic_retry, register_huey_signals,
+    register_huey_signals,
 )
 from common.logger import log
 from common.models import TaskHistory

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -1348,7 +1348,7 @@ def save_all_media_for_source(source_id):
     )
 
 
-@dynamic_retry(db_task, delay=90, priority=99, queue=Val(TaskQueue.FS))
+@db_task(delay=90, priority=99, queue=Val(TaskQueue.FS))
 def delete_all_media_for_source(source_id, source_name, source_directory):
     source = None
     assert source_id

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -450,20 +450,17 @@ def cleanup_removed_media(source_id, video_keys):
 
 
 def save_db_batch(qs, objs, fields, /):
-    assert hasattr(qs, 'bulk_update')
-    assert callable(qs.bulk_update)
-    assert hasattr(objs, '__len__')
-    assert callable(objs.__len__)
+    assert callable(getattr(qs, 'bulk_update', False))
+    assert callable(getattr(objs, '__len__', False))
     assert isinstance(fields, (tuple, list, set, frozenset))
 
     num_updated = 0
     num_objs = len(objs)
     with atomic(durable=False):
         num_updated = qs.bulk_update(objs=objs, fields=fields)
-    if num_objs == num_updated:
+    if num_objs == num_updated and callable(func := getattr(objs, 'clear', False)):
         # this covers at least: list, set, deque
-        if hasattr(objs, 'clear') and callable(objs.clear):
-            objs.clear()
+        func()
     return num_updated
 
 

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -1270,7 +1270,7 @@ def rename_all_media_for_source(source_id):
             continue
 
 
-@dynamic_retry(db_task, delay=600, priority=70, retries=15, queue=Val(TaskQueue.FS))
+@db_task(delay=600, priority=70, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.FS))
 @huey_lock_task('sync.tasks.save_all_media_for_source', queue=Val(TaskQueue.FS))
 def save_all_media_for_source(source_id):
     '''

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -1164,7 +1164,7 @@ class RefreshFormatsBackoff(BackoffAlgorithm):
 
     @staticmethod
     def calculate(attempt: int) -> int:
-        return 600 + (3600 + attempt)
+        return 600 + (3600 * attempt)
 
 @db_task(priority=50, retries=15, backoff_class=RefreshFormatsBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.LIMIT))
 def refresh_formats(media_id):

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -700,7 +700,7 @@ def index_source(source_id):
     return True
 
 
-@dynamic_retry(db_task, priority=100, retries=15, queue=Val(TaskQueue.FS))
+@db_task(priority=100, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.FS))
 def check_source_directory_exists(source_id):
     '''
         Checks the output directory for a source exists and is writable, if it does

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -709,7 +709,7 @@ def check_source_directory_exists(source_id):
         source.make_directory()
 
 
-@dynamic_retry(db_task, delay=10, priority=90, retries=15, queue=Val(TaskQueue.NET))
+@db_task(delay=10, priority=90, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.NET))
 def download_source_images(source_id):
     '''
         Downloads an image and save it as a local thumbnail attached to a

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -889,27 +889,28 @@ def download_media_metadata(media_id):
             now = timezone.now()
             published_datetime = None
 
-            parts = e_str.split(': ', 1)[1].rsplit(' ', 2)
-            unit = lambda p: str(p[-1]).lower()
-            number = lambda p: int(str(p[-2]), base=10)
-            log.debug(parts)
             try:
-                if 'days' == unit(parts):
+                parts = e_str.split(': ', 1)[1].rsplit(' ', 2)
+                log.debug(parts)
+                unit = parts[-1].lower()
+                log.debug(unit)
+                number = lambda p: int(str(p[-2]), base=10)
+
+                if 'days' == unit:
                     published_datetime = now + timedelta(days=number(parts))
-                if 'hours' == unit(parts):
+                if 'hours' == unit:
                     published_datetime = now + timedelta(hours=number(parts))
-                if 'minutes' == unit(parts):
+                if 'minutes' == unit:
                     published_datetime = now + timedelta(minutes=number(parts))
-                log.debug(unit(parts))
-                log.debug(number(parts))
-            except Exception:
+                if published_datetime:
+                    log.debug(number(parts))
+                    media.published = published_datetime
+                    media.manual_skip = True
+                    media.save()
+                    raise_exception = False
+            except (ValueError, IndexError, OverflowError):
                 log.exception('could not assign published_datetime')
 
-            if published_datetime:
-                media.published = published_datetime
-                media.manual_skip = True
-                media.save()
-                raise_exception = False
         if raise_exception:
             raise
         log.debug(str(e))
@@ -1142,44 +1143,40 @@ def rescan_media_server(mediaserver_id):
 
 @huey_task(delay=settings.MAX_RUN_TIME, expires=3600, priority=20, queue=Val(TaskQueue.NET))
 def terminate_queue_worker(media_id, worker_pid, queue, log_message):
+    proc_cmdline_path = Path(f'/proc/{worker_pid}/cmdline')
     try:
         os.kill(worker_pid, 0)
+        if not proc_cmdline_path.exists():
+            return
+        raw_bytes = proc_cmdline_path.read_bytes()
     except OSError:
-        return
-
-    proc_cmdline_path = Path(f'/proc/{worker_pid}/cmdline')
-
-    if proc_cmdline_path.exists():
+        log.exception('[Watchdog] Failed to read /proc command line')
+    else:
         try:
-            raw_bytes = proc_cmdline_path.read_bytes()
-        except Exception:
-            log.exception('[Watchdog] Failed to read /proc command line')
+            decoded_string = raw_bytes.replace(b'\x00', b'\x20').decode('utf-8')
+        except UnicodeDecodeError:
+            log.exception('[Watchdog] Failed decoding process command line payload')
         else:
-            try:
-                decoded_string = raw_bytes.replace(b'\x00', b'\x20').decode('utf-8')
-            except Exception:
-                log.exception('[Watchdog] Failed decoding process command line payload')
-            else:
-                needles = ('djangohuey', f'--queue {queue}',)
-                haystack = decoded_string.rstrip(' ')
-                if haystack.endswith(needles[-1]) and all( needle in haystack for needle in needles ):
-                    try:
-                        os.kill(worker_pid, signal.SIGKILL)
-                        log.warning('[Watchdog] %s', log_message)
-                    except OSError:
-                        log.exception('[Watchdog] Failed to kill: %d', worker_pid)
-                    else:
-                        # clear the media lock
-                        huey_lock_task(
-                            f'media:{media_id}',
-                            queue=Val(TaskQueue.DB),
-                        ).clear()
+            needles = ('djangohuey', f'--queue {queue}',)
+            haystack = decoded_string.rstrip(' ')
+            if haystack.endswith(needles[-1]) and all( needle in haystack for needle in needles ):
+                try:
+                    os.kill(worker_pid, signal.SIGKILL)
+                except OSError:
+                    log.exception('[Watchdog] Failed to kill: %d', worker_pid)
                 else:
-                    log.error(
-                        '[Watchdog] Refusing kill: PID %d was recycled by another process. '
-                        'Target media: %s Command line: "%s"',
-                        worker_pid, media_id, haystack,
-                    )
+                    log.warning('[Watchdog] %s', log_message)
+                    # clear the media lock
+                    huey_lock_task(
+                        f'media:{media_id}',
+                        queue=Val(TaskQueue.DB),
+                    ).clear()
+            else:
+                log.error(
+                    '[Watchdog] Refusing kill: PID %d was recycled by another process. '
+                    'Target media: %s Command line: "%s"',
+                    worker_pid, media_id, haystack,
+                )
 
 
 class RefreshFormatsBackoff(BackoffAlgorithm):

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -24,7 +24,10 @@ from django_huey import lock_task as huey_lock_task, task as huey_task
 from django_huey import db_periodic_task, db_task, signal as huey_signal
 from huey import crontab as huey_crontab, signals as huey_signals
 from huey.exceptions import TaskLockedException
-from common.huey import CancelExecution, dynamic_retry, register_huey_signals
+from common.huey import (
+    AttemptsTask, CancelExecution, DjangoBackgroundTasksBackoff,
+    dynamic_retry, register_huey_signals,
+)
 from common.logger import log
 from common.models import TaskHistory
 from common.errors import (
@@ -953,7 +956,7 @@ def download_media_metadata(media_id):
         metadata_lock.acquired = False
 
 
-@dynamic_retry(db_task, delay=10, priority=90, retries=15, queue=Val(TaskQueue.NET))
+@db_task(delay=10, priority=90, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.NET))
 def download_media_image(media_id, url):
     '''
         Downloads an image from a URL and save it as a local thumbnail attached to a

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -24,7 +24,10 @@ from django_huey import lock_task as huey_lock_task, task as huey_task
 from django_huey import db_periodic_task, db_task, signal as huey_signal
 from huey import crontab as huey_crontab, signals as huey_signals
 from huey.exceptions import TaskLockedException
-from common.huey import CancelExecution, dynamic_retry, register_huey_signals
+from common.huey import (
+    AttemptsTask, CancelExecution, DjangoBackgroundTasksBackoff,
+    dynamic_retry, register_huey_signals,
+)
 from common.logger import log
 from common.models import TaskHistory
 from common.errors import (
@@ -943,7 +946,7 @@ def download_media_metadata(media_id):
         metadata_lock.acquired = False
 
 
-@dynamic_retry(db_task, delay=10, priority=90, retries=15, queue=Val(TaskQueue.NET))
+@db_task(delay=10, priority=90, retries=15, backoff_class=DjangoBackgroundTasksBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.NET))
 def download_media_image(media_id, url):
     '''
         Downloads an image from a URL and save it as a local thumbnail attached to a

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -298,7 +298,6 @@ def schedule_indexing():
         except QuerySetEmptyError as e:
             msg = f'missing media from "{source.name}": {source.pk}: {e.key}'
             log.exception(msg, exc_info=e)
-            pass
         # schedule a new indexing task
         log.info(f'Scheduling an indexing task for source "{source.name}": {source.pk}')
         TaskHistory.schedule(

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -25,7 +25,7 @@ from django_huey import db_periodic_task, db_task, signal as huey_signal
 from huey import crontab as huey_crontab, signals as huey_signals
 from huey.exceptions import TaskLockedException
 from common.huey import (
-    AttemptsTask, CancelExecution, DjangoBackgroundTasksBackoff,
+    AttemptsTask, BackoffAlgorithm, CancelExecution, DjangoBackgroundTasksBackoff,
     dynamic_retry, register_huey_signals,
 )
 from common.logger import log
@@ -1178,7 +1178,14 @@ def terminate_queue_worker(media_id, worker_pid, queue, log_message):
                     )
 
 
-@dynamic_retry(db_task, backoff_func=lambda n: (n*3600)+600, priority=50, retries=15, queue=Val(TaskQueue.LIMIT))
+class RefreshFormatsBackoff(BackoffAlgorithm):
+    key = 'sync.tasks.refresh_formats'
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        return 600 + (3600 * attempt)
+
+@db_task(priority=50, retries=15, backoff_class=RefreshFormatsBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.LIMIT))
 def refresh_formats(media_id):
     try:
         media = Media.objects.get(pk=media_id)

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -25,7 +25,7 @@ from django_huey import db_periodic_task, db_task, signal as huey_signal
 from huey import crontab as huey_crontab, signals as huey_signals
 from huey.exceptions import TaskLockedException
 from common.huey import (
-    AttemptsTask, CancelExecution, DjangoBackgroundTasksBackoff,
+    AttemptsTask, BackoffAlgorithm, CancelExecution, DjangoBackgroundTasksBackoff,
     dynamic_retry, register_huey_signals,
 )
 from common.logger import log
@@ -1159,7 +1159,14 @@ def terminate_queue_worker(media_id, worker_pid, queue, log_message):
                     )
 
 
-@dynamic_retry(db_task, backoff_func=lambda n: (n*3600)+600, priority=50, retries=15, queue=Val(TaskQueue.LIMIT))
+class RefreshFormatsBackoff(BackoffAlgorithm):
+    key = 'sync.tasks.refresh_formats'
+
+    @staticmethod
+    def calculate(attempt: int) -> int:
+        return 600 + (3600 + attempt)
+
+@db_task(priority=50, retries=15, backoff_class=RefreshFormatsBackoff, task_base=AttemptsTask, queue=Val(TaskQueue.LIMIT))
 def refresh_formats(media_id):
     try:
         media = Media.objects.get(pk=media_id)

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -82,6 +82,8 @@ def map_task_to_instance(task):
     task_args = task.task_params
     if len(task_args) != 2:
         return None, None
+    # kwargs never used
+    # ruff: ignore[RUF059]
     args, kwargs = task_args
     if len(args) == 0:
         return None, None
@@ -621,6 +623,8 @@ def index_source(source_id):
             *db_fields_media,
         ).get_or_create(defaults=media_defaults, source=source, key=key)
         db_batch_media.append(media)
+        # new_data returned from get_or_create never used
+        # ruff: ignore[RUF059]
         data, new_data = source.videos.defer('value').filter(
             media__isnull=True,
         ).get_or_create(source=source, key=key)


### PR DESCRIPTION

#### Latest on this branch

```
common/huey.py:

```

```
sync/tasks.py:

```

#### Original reports from `main`

```
common/huey.py:
   22:12 BLE001 Do not catch blind exception: `Exception`
   81:9  SIM103 Return the negated condition directly
  127:13 S110 `try`-`except`-`pass` detected, consider logging the exception
  248:16 BLE001 Do not catch blind exception: `Exception`
  333:21 B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
  343:23 TRY201 Use `raise` without specifying exception name
  457:9  RUF059 Unpacked variable `created` is never used
  481:13 S110 `try`-`except`-`pass` detected, consider logging the exception
  545:13 SIM118 Use `key in dict` instead of `key in dict.keys()`
  560:30 FURB136 [*] Replace `seconds if seconds > 0 else 0` with `max(0, seconds)`

```

```
sync/tasks.py:
    82:11 RUF059 Unpacked variable `kwargs` is never used
   296:13 PIE790 [*] Unnecessary `pass` statement
   453:5  SIM102 Use a single `if` statement instead of nested `if` statements
   615:15 RUF059 Unpacked variable `new_data` is never used
   888:20 BLE001 Do not catch blind exception: `Exception`
  1129:16 BLE001 Do not catch blind exception: `Exception`
  1134:20 BLE001 Do not catch blind exception: `Exception`

```