### PR TITLE
feat: condensed storage for subtitles and automatic captions

### DIFF
--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -313,12 +313,9 @@ def parse_media_format(format_dict):
     except (ValueError, TypeError):
         width = 0
     format_full = format_dict.get('format_note', '').strip().upper()
-    format_str = format_full[:-2] if format_full.endswith('60') else format_full
-    format_str = format_str.strip()
-    format_str = format_str[:-3] if format_str.endswith('HDR') else format_str
-    format_str = format_str.strip()
-    format_str = format_str[:-2] if format_str.endswith('60') else format_str
-    format_str = format_str.strip()
+    format_str = format_full.removesuffix('60').strip()
+    format_str = format_str.removesuffix('HDR').strip()
+    format_str = format_str.removesuffix('60').strip()
     is_hls = True
     is_dash = False
     if 'DASH' in format_str:

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -81,10 +81,8 @@ def resize_image_to_height(image, width, height):
     '''
     image = image.convert('RGB')
     ratio = image.width / image.height
-    scaled_width = math.ceil(height * ratio)
-    if scaled_width < width:
-        # Width too small, stretch it
-        scaled_width = width
+    # When scaled width is too small, stretch it
+    scaled_width = max(width, math.ceil(height * ratio))
     image = image.resize((scaled_width, height), Image.LANCZOS)
     if scaled_width > width:
         # Width too large, crop it

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -164,6 +164,7 @@ def _url_keys(arg_dict, filter_func):
     return result
 
 
+# ruff: disable[SIM118]
 # expects a dictionary where the value at key is a:
 # list of dictionaries 
 def _drop_url_keys(arg_dict, key, filter_func):
@@ -284,6 +285,7 @@ def filter_response(arg_dict, copy_arg=False):
     # end of heatmap cleanup }}}
 
     return response_dict
+# ruff: enable[SIM118]
 
 
 def parse_media_format(format_dict):

--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -242,12 +242,41 @@ def filter_response(arg_dict, copy_arg=False):
             )
         )
 
+    def condense_exts(arg_dict, key):
+        mapped, result_list = list_of_dictionaries(arg_dict[key], extract_exts)
+        if mapped:
+            acc = dict(names=set(), exts=dict())
+            for t in result_list:
+                reduce_ext(t, acc)
+            # promote for the shared name case, otherwise keep everything
+            if 1 == len(acc['names']):
+                acc['exts'] = sorted(e for s in acc['exts'].values() for e in s)
+                arg_dict[key] = [acc]
+            elif acc['names']:
+                arg_dict[key] = [acc]
+
+    def extract_exts(arg_dict):
+        ext = arg_dict.get('ext')
+        name = arg_dict.get('name')
+        return (name, ext)
+
+    def reduce_ext(t, results):
+        name, ext = t
+        if not name:
+            return
+        results['names'].add(name)
+        exts = results['exts'].get(name, set())
+        results['exts'][name] = exts
+        if ext:
+            exts.add(ext)
+
     for key in ('subtitles', 'requested_subtitles', 'automatic_captions',):
         if key in response_dict.keys():
             lang_codes = response_dict[key]
             if isinstance(lang_codes, dict):
                 for lang_code in lang_codes.keys():
                     _drop_url_keys(lang_codes, lang_code, drop_subtitles_url)
+                    condense_exts(lang_codes, lang_code)
     # end of subtitles cleanup }}}
  
     # beginning of heatmap cleanup {{{


### PR DESCRIPTION

Fixes #1554 

### Lint complaints

- [E741](https://docs.astral.sh/ruff/rules/ambiguous-variable-name/#why-is-this-bad): Use a better font. 🤔

```
sync/utils.py:
   85:5  PLR1730 Replace `if` statement with `scaled_width = max(scaled_width, width)`
  178:8  SIM118 Use `key in dict` instead of `key in dict.keys()`
  223:16 SIM118 Use `key in dict` instead of `key in dict.keys()`
  227:12 SIM118 Use `key in dict` instead of `key in dict.keys()`
  274:12 SIM118 Use `key in dict` instead of `key in dict.keys()`
  277:21 SIM118 Use `key in dict` instead of `key in dict.keys()`
  284:12 SIM118 Use `key in dict` instead of `key in dict.keys()`
  316:18 FURB188 [*] Prefer `str.removesuffix()` over conditionally replacing with slice.
  318:18 FURB188 [*] Prefer `str.removesuffix()` over conditionally replacing with slice.
  320:18 FURB188 [*] Prefer `str.removesuffix()` over conditionally replacing with slice.
```