### PR TITLE
fix: add genpts to ffmpeg flags for Merger

### DIFF
--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -379,6 +379,7 @@ YOUTUBE_DEFAULTS = {
     },
     'postprocessor_args': {
         'videoremuxer+ffmpeg': ['-bsf:v', 'setts=pts=DTS'],
+        'merger+ffmpeg': ['-fflags', '+genpts'],
     },
     'js_runtimes': {
         'deno': {'path': None,},


### PR DESCRIPTION

`--postprocessor-args merger+ffmpeg:-fflags +genpts`

Fixes #1573 
