### PR TITLE
feat: integrate django-tasks-db

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pycodestyle = "*"
 [packages]
 django = "~=6.0.0"
 django-huey = "*"
+django-tasks-db = "*"
 django-sass-processor = {extras = ["management-command"], version = "*"}
 pillow = "*"
 whitenoise = "*"

--- a/tubesync/common/huey.py
+++ b/tubesync/common/huey.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import concurrent.futures
 import datetime
 import subprocess
+import threading
 import time
 import uuid
 from functools import partial
@@ -479,6 +481,7 @@ def historical_task(signal_name, task_obj, exception_obj=None, /, *, huey=None):
 def register_huey_signals():
     from django import db
     from django_huey import DJANGO_HUEY, get_queue, pre_execute, post_execute, signal
+
     def close_db(task, task_value=None, exception=None, /, *, huey=None):
         assert huey is not None
         assert hasattr(huey, 'immediate')
@@ -490,21 +493,13 @@ def register_huey_signals():
             return
         db.close_old_connections()
 
-    for qn in DJANGO_HUEY.get('queues', dict()):
+    def prune_queue_storage(qn):
+        # clean up old history and results from storage
         q = get_queue(qn)
 
-        # hooks to clean up database connections at task boundaries
-        pre_execute(queue=qn, name='close_db')(partial(close_db, huey=q))
-        post_execute(queue=qn, name='close_db')(partial(close_db, huey=q))
-
-        # signals for tracking / maintenance of tasks
-        signal(signals.SIGNAL_INTERRUPTED, queue=qn)(on_interrupted)
-        signal(queue=qn)(historical_task)
-        signal(signals.SIGNAL_EXECUTING, queue=qn)(on_executing_remove_duplicates)
-
-        # clean up old history and results from storage
         now_time = time.monotonic()
         now_dt = datetime.datetime.now(datetime.timezone.utc)
+
         # ruff: ignore[SIM118]
         for key in q.all_results().keys():
             if not key.startswith(storage_key_prefix):
@@ -529,6 +524,44 @@ def register_huey_signals():
                 result_key = key[len(storage_key_prefix) :]
                 q.get(peek=False, key=result_key)
                 q.get(peek=False, key=key)
+
+    def _run_cleanup(qn):
+        def _target():
+            try:
+                prune_queue_storage(qn)
+            except Exception:
+                from common.logger import log
+                log.exception(f'Cleanup of {qn=} failed.')
+        # The pruning is happening opportunistically;
+        # short running tasks won't wait for these threads.
+        worker = threading.Thread(target=_target, daemon=True)
+        worker.queue_name = qn
+        threads.add(worker)
+        worker.start()
+
+    queues = { qn: get_queue(qn) for qn in DJANGO_HUEY.get('queues', dict()) }
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=get_usable_cpu_count(),
+    )
+    threads = set()
+    for qn, q in queues.items():
+        # hooks to clean up database connections at task boundaries
+        pre_execute(queue=qn, name='close_db')(partial(close_db, huey=q))
+        post_execute(queue=qn, name='close_db')(partial(close_db, huey=q))
+
+        # signals for tracking / maintenance of tasks
+        signal(signals.SIGNAL_INTERRUPTED, queue=qn)(on_interrupted)
+        signal(queue=qn)(historical_task)
+        signal(signals.SIGNAL_EXECUTING, queue=qn)(on_executing_remove_duplicates)
+
+        # prune the queue storage
+        executor.submit(_run_cleanup, qn)
+
+    # wait for the worker threads to start,
+    # not for the storage pruning tasks to finish
+    executor.shutdown(wait=True)
+
+    return threads
 
 
 class BackoffAlgorithm:

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -388,7 +388,7 @@ def cleanup_huey_storage():
             pass
         worker.join()
     workers.clear()
-cleanup_huey_storage_result = cleanup_huey_storage.enqueue()
+#cleanup_huey_storage_result = cleanup_huey_storage.enqueue()
 
 
 @db_task(priority=90, retries=2, retry_delay=150, queue=Val(TaskQueue.FS))

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -383,7 +383,7 @@ def cleanup_huey_storage():
         return
     for worker in workers:
         try:
-            w.start()
+            worker.start()
         except RuntimeError:
             pass
         worker.join()

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -45,7 +45,6 @@ from .utils import get_remote_image, resize_image_to_height, filter_response
 from .youtube import YouTubeError
 
 atomic = db.transaction.atomic
-db_vendor = db.connection.vendor
 register_huey_signals()
 
 
@@ -207,7 +206,7 @@ def cleanup_completed_tasks():
 def save_model(instance):
     with atomic(durable=False):
         instance.save()
-    if 'sqlite' != db_vendor:
+    if 'sqlite' != db.connection.vendor:
         return
 
     # work around for SQLite and its many

--- a/tubesync/sync/tasks.py
+++ b/tubesync/sync/tasks.py
@@ -18,6 +18,7 @@ from shutil import copyfile, rmtree
 from django import db
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.tasks import task as django_task
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_huey import lock_task as huey_lock_task, task as huey_task
@@ -45,7 +46,7 @@ from .utils import get_remote_image, resize_image_to_height, filter_response
 from .youtube import YouTubeError
 
 atomic = db.transaction.atomic
-register_huey_signals()
+cleanup_threads = register_huey_signals()
 
 
 def get_task_map():
@@ -369,6 +370,25 @@ def wait_for_errors(model, /, *, queue_name=None, task_name=None):
         update_task_status(task, None)
     if delay > 0:
         raise HueyConsumerError(_('queue consumer stopped'))
+
+
+@django_task(queue_name=Val(TaskQueue.FS))
+def cleanup_huey_storage():
+    workers = cleanup_threads
+    if not all(
+        (callable(getattr(workers, 'clear', None)),) +
+        tuple(callable(getattr(w, 'join', None)) for w in workers) +
+        tuple(callable(getattr(w, 'start', None)) for w in workers),
+    ):
+        return
+    for worker in workers:
+        try:
+            w.start()
+        except RuntimeError:
+            pass
+        worker.join()
+    workers.clear()
+cleanup_huey_storage_result = cleanup_huey_storage.enqueue()
 
 
 @db_task(priority=90, retries=2, retry_delay=150, queue=Val(TaskQueue.FS))

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -55,7 +55,7 @@ FORCE_SCRIPT_NAME = None
 TASKS = {
     "default": {
         "BACKEND": "django_tasks_db.DatabaseBackend",
-        "QUEUES": [ qn for qn in TaskQueue.values ],
+        "QUEUES": TaskQueue.values + ['default'],
     },
 }
 

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -53,9 +53,9 @@ FORCE_SCRIPT_NAME = None
 
 
 TASKS = {
-    "default": {
-        "BACKEND": "django_tasks_db.DatabaseBackend",
-        "QUEUES": TaskQueue.values + ['default'],
+    'default': {
+        'BACKEND': 'django_tasks_db.DatabaseBackend',
+        'QUEUES': TaskQueue.values + ['default'],
     },
 }
 

--- a/tubesync/tubesync/settings.py
+++ b/tubesync/tubesync/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
     'django.contrib.humanize',
     'sass_processor',
     'django_huey',
+    'django_tasks_db',
     'common',
     'sync',
 ]
@@ -50,6 +51,13 @@ MIDDLEWARE = [
 ROOT_URLCONF = 'tubesync.urls'
 FORCE_SCRIPT_NAME = None
 
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks_db.DatabaseBackend",
+        "QUEUES": [ qn for qn in TaskQueue.values ],
+    },
+}
 
 DJANGO_HUEY = {
     'default': TaskQueue.LIMIT.value,


### PR DESCRIPTION
### TODO

- [ ] Services for the consumer workers
- [ ] Enqueue startup tasks in ready

### Repository

https://github.com/RealOrangeOne/django-tasks-db

### Queues

1. `database`
2. `filesystem`
3. `network`
4. `limited`
5. `default`

A worker service for `limited`. Multiple worker services for the remaining queues.

### Services

Bundle: `django-tasks-consumers`

1. `django-tasks-default`
2. `django-tasks-net-limited`

Flags: `-v 2 --no-reload --interval 20 --max-tasks 100 --queue-name '*' --exclude-queues limited`

### Worker

<details><summary>usage output</summary>

```
usage: manage.py db_worker [-h] [--queue-name [QUEUE_NAME]]
                           [--exclude-queues [EXCLUDE_QUEUES]]
                           [--interval [INTERVAL]] [--batch]
                           [--reload | --no-reload]
                           [--backend [BACKEND_NAME]]
                           [--no-startup-delay]
                           [--max-tasks [MAX_TASKS]]
                           [--worker-id [WORKER_ID]] [--version]
                           [-v {0,1,2,3}] [--settings SETTINGS]
                           [--pythonpath PYTHONPATH] [--traceback]
                           [--no-color] [--force-color]
                           [--skip-checks]

Run a database background worker

options:
  -h, --help            show this help message and exit
  --queue-name [QUEUE_NAME]
                        The queues to process. Separate multiple with a comma.
                        To process all queues, use '*' (default: 'default')
  --exclude-queues [EXCLUDE_QUEUES]
                        Queues to exclude. Separate multiple with a comma.
  --interval [INTERVAL]
                        The interval (in seconds) to wait, when
                        there are no tasks in the queue, before
                        checking for tasks again (default: 1)
  --batch               Process all outstanding tasks, then exit.
                        Can be used in combination with --max-                               tasks.
  --reload, --no-reload
                        Reload the worker on code changes.
                        Not recommended for production as tasks may not
                        be stopped cleanly (default: DEBUG)
  --backend [BACKEND_NAME]
                        The backend to operate on (default: 'default')
  --no-startup-delay    Don't add a small delay at startup.
  --max-tasks [MAX_TASKS]
                        If provided, the maximum number of tasks
                        the worker will execute before exiting.
  --worker-id [WORKER_ID]
                        Worker id. MUST be unique across worker
                        pool (default: auto-generate)
  --version             Show program's version number and exit.
  -v, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't
                        provided, the DJANGO_SETTINGS_MODULE
                        environment variable will be used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Display a full stack trace on CommandError exceptions.
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
  --skip-checks         Skip system checks.

```

</details>
