### PR TITLE
chore: upgrade `bgutil-ytdlp-pot-provider` to `2.0.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-ARG BGUTIL_YTDLP_POT_PROVIDER_VERSION="1.3.2"
+ARG BGUTIL_YTDLP_POT_PROVIDER_VERSION="2.0.0"
 ARG FFMPEG_VERSION="N"
 ARG YTDLP_EJS_VERSION="0.8.0"
 
@@ -500,7 +500,7 @@ RUN --mount=type=bind,source=fontawesome-free,target=/fontawesome-free \
   mv -v /app/tubesync/local_settings.py.container /app/tubesync/local_settings.py
 
 ARG BGUTIL_YTDLP_POT_PROVIDER_VERSION
-ADD --checksum=7511309af023b09788dc8f2efc96cc3671291e6c "https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git#${BGUTIL_YTDLP_POT_PROVIDER_VERSION}:server" /app/bgutil-ytdlp-pot-provider/server
+ADD --checksum=37169ee2656e08c5c2e5dc9df4c598c0cb4c88a8 "https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git#${BGUTIL_YTDLP_POT_PROVIDER_VERSION}:server" /app/bgutil-ytdlp-pot-provider/server
 RUN ls -alR /app/bgutil-ytdlp-pot-provider
 
 ARG YTDLP_EJS_VERSION

--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ yt-dlp = {extras = ["default", "curl-cffi"], version = "*"}
 emoji = "*"
 brotli = "*"
 html5lib = "*"
-bgutil-ytdlp-pot-provider = "==1.3.2"
+bgutil-ytdlp-pot-provider = "==2.0.0"
 yt-dlp-remote-cipher = "*"
 babi = "*"
 hat-syslog = "==0.7.28"


### PR DESCRIPTION
Upgrades `bgutil-ytdlp-pot-provider` from `1.3.2` to `2.0.0`.

- Dockerfile: bump version ARG and update ADD checksum
- Pipfile: bump pinned version